### PR TITLE
Pr for failure fix

### DIFF
--- a/examples/test_metadata.py
+++ b/examples/test_metadata.py
@@ -1,6 +1,6 @@
 import sys
 import os.path as op
-
+import six
 sys.path.insert(0, op.dirname(op.dirname(op.abspath(__file__))))
 from solnlib import metadata
 import context
@@ -10,7 +10,7 @@ def test_metadata_reader():
     mr = metadata.MetadataReader(context.app)
 
     modtime = mr.get('collections', 'sessions', 'modtime')
-    assert type(modtime.encode('UTF-8')) == str
+    assert isinstance(modtime, six.text_type)
 
     modtime = mr.get_float('collections', 'sessions', 'modtime')
     assert type(modtime) == float

--- a/examples/test_server_info.py
+++ b/examples/test_server_info.py
@@ -32,6 +32,6 @@ def test_server_info():
     try:
         shc_members = si.get_shc_members()
     except server_info.ServerInfoException as e:
-        print(e.message)
+        print(e)
     else:
         print('    -SHC members are: ', shc_members)

--- a/examples/test_user_access.py
+++ b/examples/test_user_access.py
@@ -31,8 +31,8 @@ def test_object_acl_manager():
                      context.app, context.owner, obj_perms2, True,
                      replace_existing=False)
     obj_acl = oaclm.get_acl(obj_collection, obj_id1)
-    assert obj_acl.obj_perms['read'] == ['admin', 'user1']
-
+    assert set((obj_acl.obj_perms['read'])) == set(['admin', 'user1'])
+   
     oaclm.update_acls(obj_collection, [obj_id2, obj_id3], obj_type,
                       context.app, context.owner, obj_perms1, True)
     oaclm.get_acl(obj_collection, obj_id2)


### PR DESCRIPTION
- In test_metadeta.py in python 3 it was getting converted to byte format and unicode in python2 so used six package which matches unicode in python2 and string in python3.
- In test_user_access used set to match list.
- In test_serverinfo the exception message printed was python2 specific to updated that to make it python2 and python3 compatible.