### PR TITLE
Fix collection name length: generated name would break splunk kvstore…

### DIFF
--- a/solnlib/modular_input/modular_input.py
+++ b/solnlib/modular_input/modular_input.py
@@ -180,9 +180,7 @@ class ModularInput(metaclass=ABCMeta):
 
     def _create_checkpointer(self):
         if self.use_kvstore_checkpointer:
-            checkpointer_name = ":".join(
-                [self.app, self.config_name, self.kvstore_checkpointer_collection_name]
-            )
+            checkpointer_name = self.kvstore_checkpointer_collection_name
             try:
                 return checkpointer.KVStoreCheckpointer(
                     checkpointer_name,


### PR DESCRIPTION
see [Issue 18](https://github.com/splunk/addonfactory-solutions-library-python/issues/18)