### PR TITLE
fix: remove json related functions

### DIFF
--- a/solnlib/utils.py
+++ b/solnlib/utils.py
@@ -31,7 +31,6 @@ __all__ = [
     "datetime_to_seconds",
     "is_true",
     "is_false",
-    "escape_json_control_chars",
     "retry",
     "extract_http_scheme_host_port",
 ]
@@ -99,38 +98,6 @@ def is_false(val: Union[str, int]) -> bool:
     if value in ("0", "FALSE", "F", "N", "NO", "NONE", ""):
         return True
     return False
-
-
-def escape_json_control_chars(json_str: str) -> str:
-    """Escape json control chars in `json_str`.
-
-    Arguments:
-        json_str: Json string to escape.
-
-    Returns:
-        Escaped string.
-    """
-
-    control_chars = ((r"\n", "\\\\n"), (r"\r", "\\\\r"), (r"\r\n", "\\\\r\\\\n"))
-    for ch, replace in control_chars:
-        json_str = json_str.replace(ch, replace)
-    return json_str
-
-
-def unescape_json_control_chars(json_str: str) -> str:
-    """Unescape json control chars in `json_str`.
-
-    Arguments:
-        json_str: Json string to unescape.
-
-    Returns:
-        Unescaped string.
-    """
-
-    control_chars = (("\\\\n", r"\n"), ("\\\\r", r"\r"), ("\\\\r\\\\n", r"\r\n"))
-    for ch, replace in control_chars:
-        json_str = json_str.replace(ch, replace)
-    return json_str
 
 
 def retry(

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -64,20 +64,6 @@ def test_is_true(monkeypatch):
         assert not utils.is_true(val)
 
 
-def test_escape_json_control_chars(monkeypatch):
-    str1 = r"hello\nworld"
-    escaped_str1 = r"hello\\nworld"
-    assert escaped_str1 == utils.escape_json_control_chars(str1)
-
-    str1 = r"hello\rworld"
-    escaped_str1 = r"hello\\rworld"
-    assert escaped_str1 == utils.escape_json_control_chars(str1)
-
-    str1 = r"hello\r\nworld"
-    escaped_str1 = r"hello\\r\\nworld"
-    assert escaped_str1 == utils.escape_json_control_chars(str1)
-
-
 def test_retry(monkeypatch):
     def _old_func():
         raise ValueError("Exception for test.")


### PR DESCRIPTION
Removes escape_json_control_chars and unescape_json_control_chars as they are not used across add-ons and should not be a part of solnlib.