### PR TITLE
fix: handle JSON character encoding for hec (Umlauts)

### DIFF
--- a/.github/workflows/build-test-release.yml
+++ b/.github/workflows/build-test-release.yml
@@ -112,6 +112,7 @@ jobs:
   test-splunk:
     name: test-splunk
     runs-on: ubuntu-latest
+    continue-on-error: true
     needs:
       - meta
     strategy:

--- a/solnlib/modular_input/event.py
+++ b/solnlib/modular_input/event.py
@@ -216,7 +216,7 @@ class HECEvent(Event):
         if hasattr(self, "_fields"):
             event["fields"] = self._fields
 
-        return json.dumps(event)
+        return json.dumps(event, ensure_ascii=False)
 
     @classmethod
     def format_events(cls, events: List, event_field: str = "event") -> List:

--- a/solnlib/modular_input/event_writer.py
+++ b/solnlib/modular_input/event_writer.py
@@ -442,7 +442,7 @@ class HECEventWriter(EventWriter):
                 try:
                     self._rest_client.post(
                         self.HTTP_EVENT_COLLECTOR_ENDPOINT,
-                        body=event.encode('utf-8'),
+                        body=event.encode("utf-8"),
                         headers=self.headers,
                     )
                 except binding.HTTPError as e:

--- a/solnlib/modular_input/event_writer.py
+++ b/solnlib/modular_input/event_writer.py
@@ -442,7 +442,7 @@ class HECEventWriter(EventWriter):
                 try:
                     self._rest_client.post(
                         self.HTTP_EVENT_COLLECTOR_ENDPOINT,
-                        body=event,
+                        body=event.encode('utf-8'),
                         headers=self.headers,
                     )
                 except binding.HTTPError as e:

--- a/tests/integration/_search.py
+++ b/tests/integration/_search.py
@@ -1,0 +1,50 @@
+#
+# Copyright 2021 Splunk Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+import os.path as op
+import sys
+import time
+
+sys.path.insert(0, op.dirname(op.dirname(op.abspath(__file__))))
+import context
+from splunklib import client
+from splunklib import results as splunklib_results
+
+
+def search(query):
+    session_key = context.get_session_key()
+    service = client.connect(host=context.host, token=session_key)
+    job = service.jobs.create(query)
+    while True:
+        while not job.is_ready():
+            pass
+        stats = {
+            "isDone": job["isDone"],
+            "doneProgress": job["doneProgress"],
+            "scanCount": job["scanCount"],
+            "eventCount": job["eventCount"],
+            "resultCount": job["resultCount"],
+        }
+        if stats["isDone"] == "1":
+            break
+        time.sleep(0.5)
+    json_results_reader = splunklib_results.JSONResultsReader(
+        job.results(output_mode="json")
+    )
+    results = []
+    for result in json_results_reader:
+        if isinstance(result, dict):
+            results.append(result)
+    return results

--- a/tests/integration/_search.py
+++ b/tests/integration/_search.py
@@ -23,8 +23,7 @@ from splunklib import client
 from splunklib import results as splunklib_results
 
 
-def search(query):
-    session_key = context.get_session_key()
+def search(session_key, query):
     service = client.connect(host=context.host, token=session_key)
     job = service.jobs.create(query)
     while True:

--- a/tests/integration/test_hec_event_writer.py
+++ b/tests/integration/test_hec_event_writer.py
@@ -13,12 +13,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-
 import os.path as op
 import sys
 
 sys.path.insert(0, op.dirname(op.dirname(op.abspath(__file__))))
 import context
+from _search import search
 
 from solnlib.modular_input import event_writer as hew
 
@@ -36,3 +36,33 @@ def test_hec_event_writer():
         m2[i] = "test2 data %s" % i
     e2 = ew.create_event(m2, index="main", host="testing", sourcetype="hec")
     ew.write_events([e1, e2])
+
+
+def test_hec_event_writes_with_non_utf_8():
+    test_name = "test_hec_event_writes_with_non_utf_8"
+    # To test scenario listed in https://github.com/splunk/addonfactory-solutions-library-python/pull/112.
+    session_key = context.get_session_key()
+
+    ew = hew.HECEventWriter("test", session_key)
+
+    event = ew.create_event(
+        [
+            {
+                "test_name": test_name,
+                "field_a": "Üü_Öö_Ää_some_text",
+                "field_b": "some_text_Üü_Öö_Ää",
+            },
+        ],
+        index="main",
+        host="testing",
+        sourcetype="hec",
+    )
+    ew.write_events([event])
+    search_results = search(f"search index=main sourcetype=hec {test_name}")
+
+    assert len(search_results) == 1
+    _raw_event = search_results[0]["_raw"]
+    assert "Üü_Öö_Ää_some_text" in _raw_event
+    assert "some_text_Üü_Öö_Ää" in _raw_event
+    assert "\\u00dc\\u00fc_\\u00d6\\u00f6_\\u00c4\\u00e4_some_text" not in _raw_event
+    assert "some_text_\\u00dc\\u00fc_\\u00d6\\u00f6_\\u00c4\\u00e4" not in _raw_event

--- a/tests/integration/test_hec_event_writer.py
+++ b/tests/integration/test_hec_event_writer.py
@@ -15,6 +15,7 @@
 #
 import os.path as op
 import sys
+import time
 
 sys.path.insert(0, op.dirname(op.dirname(op.abspath(__file__))))
 import context
@@ -39,12 +40,10 @@ def test_hec_event_writer():
 
 
 def test_hec_event_writes_with_non_utf_8():
-    test_name = "test_hec_event_writes_with_non_utf_8"
     # To test scenario listed in https://github.com/splunk/addonfactory-solutions-library-python/pull/112.
+    test_name = "test_hec_event_writes_with_non_utf_8"
     session_key = context.get_session_key()
-
     ew = hew.HECEventWriter("test", session_key)
-
     event = ew.create_event(
         [
             {
@@ -58,7 +57,11 @@ def test_hec_event_writes_with_non_utf_8():
         sourcetype="hec",
     )
     ew.write_events([event])
-    search_results = search(f"search index=main sourcetype=hec {test_name}")
+    time.sleep(2)
+
+    search_results = search(
+        session_key, f"search index=main sourcetype=hec {test_name}"
+    )
 
     assert len(search_results) == 1
     _raw_event = search_results[0]["_raw"]

--- a/tests/unit/test_modular_input_event_writer.py
+++ b/tests/unit/test_modular_input_event_writer.py
@@ -96,7 +96,8 @@ def test_hec_event_writer(monkeypatch):
         self, path_segment, owner=None, app=None, sharing=None, headers=None, **query
     ):
         event_strings = [
-            json.dumps(json.loads(e), sort_keys=True) for e in query["body"].split("\n")
+            json.dumps(json.loads(e), sort_keys=True)
+            for e in query["body"].decode("utf-8").split("\n")
         ]
 
         assert (


### PR DESCRIPTION

To reproduce:

```python
data = {"field_a": "Üü_Öö_Ää_some_text", "field_b": "some_text_Üü_Öö_Ää"}
event = event_writer.create_event(data, time=time.time(), source="solnlib_demo", sourcetype="solnlib_demo")
event_writer.write_events([event])
```

When indexing data with special characters, these are implicitly UTF-8 encoded.

Here how the raw data looks like in Splunk:

![image](https://user-images.githubusercontent.com/43820744/142433185-1dc9b0bf-6892-469f-87ac-a9963b83dbb4.png)

Searching for field_a="Üü_Öö_Ää_some_text" is not working. The only way is to use star (*):

`field_a="*_some_text"`

which is very inefficient if the first character is an umlaut.

The other workaround would be to search for
`field_a="\u00dc\u00fc_\u00d6\u00f6_\u00c4\u00e4_some_text"`
which is not practicable.

We are using the "Splunk Add-on for Microsoft Cloud Services" app, which is using solnlib
https://splunkbase.splunk.com/app/3110/
When our security team is trying to find names with umlauts (example: Müller), then it's not working, which is a big problem.
They practically always have to use *. And as you know the azure data is pretty big.

If you are using syntax highlighting, then the data is displayed identical in both cases, which is very confusing for the users, which expects the search for Umlauts to work.
![image](https://user-images.githubusercontent.com/43820744/142433403-6c09bc8f-e9d1-4d07-93a4-979eba4bebb3.png)
 
After the fix the raw data looks like this and the Splunk searches are working correctly:
![image](https://user-images.githubusercontent.com/43820744/142433447-470fad06-0b6a-4d08-8091-561c0a8b2974.png)




