### PR TITLE
feat: add ServerInfo's from_server_uri and to_dict

### DIFF
--- a/tests/integration/test_server_info.py
+++ b/tests/integration/test_server_info.py
@@ -13,28 +13,33 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-import unittest
-
 import context
+import pytest
 
 from solnlib import server_info
 
 
-class ServerInfoTest(unittest.TestCase):
-    def test_methods(self):
-        # This test does not check for guid, version and SHC related methods.
-        session_key = context.get_session_key()
-        si = server_info.ServerInfo(
-            session_key, context.scheme, context.host, context.port
-        )
-        self.assertEqual("custom-servername", si.server_name)
-        self.assertFalse(si.is_search_head())
-        self.assertFalse(si.is_shc_member())
-        with self.assertRaises(server_info.ServerInfoException):
-            si.get_shc_members()
-        with self.assertRaises(server_info.ServerInfoException):
-            si.captain_info()
-        with self.assertRaises(server_info.ServerInfoException):
-            si.is_captain_ready()
-        self.assertFalse(si.is_captain())
-        self.assertFalse(si.is_cloud_instance())
+def test_server_info_methods():
+    # This test does not check for guid, version and SHC related methods.
+    session_key = context.get_session_key()
+    si = server_info.ServerInfo(session_key, context.scheme, context.host, context.port)
+    assert "custom-servername" == si.server_name
+    assert si.is_search_head() is False
+    assert si.is_shc_member() is False
+    with pytest.raises(server_info.ServerInfoException):
+        si.get_shc_members()
+    with pytest.raises(server_info.ServerInfoException):
+        si.captain_info()
+    with pytest.raises(server_info.ServerInfoException):
+        si.is_captain_ready()
+    assert si.is_captain() is False
+    assert si.is_cloud_instance() is False
+
+
+def test_from_server_uri():
+    session_key = context.get_session_key()
+    si = server_info.ServerInfo.from_server_uri(
+        f"{context.scheme}://{context.host}:{context.port}", session_key
+    )
+    # Run 1 small test to check that .from_server_uri is working.
+    assert "custom-servername" == si.server_name

--- a/tests/unit/test_server_info.py
+++ b/tests/unit/test_server_info.py
@@ -14,19 +14,24 @@
 # limitations under the License.
 #
 import common
+import pytest
 from splunklib import binding
 
 from solnlib import server_info
 
 
+def test_from_server_uri():
+    server_info.ServerInfo.from_server_uri("https://localhost:8089", common.SESSION_KEY)
+
+
+def test_from_server_uri_when_invalid_server_uri():
+    with pytest.raises(ValueError):
+        server_info.ServerInfo.from_server_uri(
+            "no-schema://localhost:99999", common.SESSION_KEY
+        )
+
+
 class TestServerInfo:
-    def test_version(self, monkeypatch):
-        common.mock_splunkhome(monkeypatch)
-        common.mock_serverinfo(monkeypatch)
-
-        si = server_info.ServerInfo(common.SESSION_KEY)
-        assert si.version == "6.3.1511.2"
-
     def test_get_shc_members(self, monkeypatch):
         def _mock_get(self, path_segment, owner=None, app=None, sharing=None, **query):
             return common.make_response_record(


### PR DESCRIPTION
This commit introduces 2 new methods for ServerInfo class, 2 methods that are missing from splunktalib's implementation of ServerInfo.

After this commit is merged, splunktalib's implementation can be deprecated, because solnlib's implementation supports everything and even more.