### PR TITLE
ci: use reusable workflows for agreements and release notes

### DIFF
--- a/.github/workflows/agreements.yaml
+++ b/.github/workflows/agreements.yaml
@@ -6,40 +6,8 @@ on:
     types: [opened, closed, synchronize]
 
 jobs:
-  ContributorLicenseAgreement:
-    runs-on: ubuntu-latest
-    steps:
-      - name: "CLA Assistant"
-        if: (github.event.comment.body == 'recheck' || github.event.comment.body == 'I have read the CLA Document and I hereby sign the CLA') || github.event_name == 'pull_request_target'
-        uses: cla-assistant/github-action@v2.1.3-beta
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          PERSONAL_ACCESS_TOKEN: ${{ secrets.PAT_CLATOOL }}
-        with:
-          path-to-signatures: "signatures/version1/cla.json"
-          path-to-document: "https://github.com/splunk/cla-agreement/blob/main/CLA.md" # e.g. a CLA or a DCO document
-          branch: "main"
-          allowlist: dependabot[bot]
-          remote-organization-name: splunk
-          remote-repository-name: cla-agreement
-  CodeOfConduct:
-    runs-on: ubuntu-latest
-    steps:
-      - name: "COC Assistant"
-        if: (github.event.comment.body == 'recheck' || github.event.comment.body == 'I have read the Code of Conduct and I hereby accept the Terms') || github.event_name == 'pull_request_target'
-        uses: cla-assistant/github-action@v2.1.3-beta
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          PERSONAL_ACCESS_TOKEN: ${{ secrets.PAT_CLATOOL }}
-        with:
-          path-to-signatures: "signatures/version1/coc.json"
-          path-to-document: "https://github.com/splunk/cla-agreement/blob/main/CODE_OF_CONDUCT.md" # e.g. a COC or a DCO document
-          branch: "main"
-          allowlist: dependabot[bot]
-          remote-organization-name: splunk
-          remote-repository-name: cla-agreement
-          custom-pr-sign-comment: "I have read the Code of Conduct and I hereby accept the Terms"
-          create-file-commit-message: "For example: Creating file for storing COC Signatures"
-          signed-commit-message: "$contributorName has signed the COC in #$pullRequestNo"
-          custom-notsigned-prcomment: "All contributors have NOT signed the COC Document"
-          custom-allsigned-prcomment: "****CLA Assistant Lite bot**** All contributors have signed the COC  ✍️ ✅"
+  call-workflow-agreements:
+    uses: arys-splunk/github-workflows-reuse/.github/workflows/agreements.yml@main
+    secrets:
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      PERSONAL_ACCESS_TOKEN: ${{ secrets.PAT_CLATOOL }}

--- a/.github/workflows/build-test-release.yml
+++ b/.github/workflows/build-test-release.yml
@@ -59,7 +59,7 @@ jobs:
           python-version: "3.7"
       - name: Install actionlint
         run: |
-          bash <(curl https://raw.githubusercontent.com/rhysd/actionlint/v1.6.3/scripts/download-actionlint.bash)
+          bash <(curl https://raw.githubusercontent.com/rhysd/actionlint/v1.6.8/scripts/download-actionlint.bash)
       - uses: pre-commit/action@v2.0.3
 
   review_secrets:

--- a/.github/workflows/release-notes.yaml
+++ b/.github/workflows/release-notes.yaml
@@ -6,15 +6,7 @@ on:
     types: [edited]
 
 jobs:
-  preview:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - run: |
-          git fetch --prune --unshallow --tags
-      - uses: snyk/release-notes-preview@v1.6.2
-        with:
-          releaseBranch: main
-        env:
-          GITHUB_PR_USERNAME: ${{ github.actor }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  call-workflow-preview:
+    uses: arys-splunk/github-workflows-reuse/.github/workflows/release-notes.yml@main
+    secrets:
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Github introduced reusable workflows: https://docs.github.com/en/actions/learn-github-actions/reusing-workflows so we can leverage them by replacing agreements and other popular simple workflows to use 1 centralised version.