### PR TITLE
ci: update poetry installation command

### DIFF
--- a/.github/workflows/build-test-release.yml
+++ b/.github/workflows/build-test-release.yml
@@ -99,8 +99,6 @@ jobs:
       - name: run tests
         run: |
           curl -sSL https://install.python-poetry.org | python3 -
-          # shellcheck disable=SC1090
-          source "$HOME/.poetry/env"
           poetry install
           poetry run pytest --junitxml=test-results/results.xml --cov=solnlib --cov-report=xml:unit_tests_coverage.xml tests/unit
       - uses: actions/upload-artifact@v2
@@ -155,8 +153,6 @@ jobs:
       - name: Run tests
         run: |
           curl -sSL https://install.python-poetry.org | python3 -
-          # shellcheck disable=SC1090
-          source "$HOME/.poetry/env"
           poetry install
           SPLUNK_HOME=/opt/splunk/ poetry run pytest --cov=solnlib --junitxml=test-results/results.xml --cov-report=xml:integration_tests_coverage_${{ matrix.splunk-version }}.xml -v tests/integration
       - uses: actions/upload-artifact@v2.2.4
@@ -217,16 +213,9 @@ jobs:
         with:
           python-version: "3.7"
       - name: Install Poetry
-        run: curl -sSL https://install.python-poetry.org | python3 -
-      - name: Install Code
         run: |
-          # shellcheck disable=SC1090
-          source "$HOME/.poetry/env"
+          curl -sSL https://install.python-poetry.org | python3 -
           poetry install
-      - name: Build
-        run: |
-          # shellcheck disable=SC1090
-          source "$HOME/.poetry/env"
           poetry build
       - name: Semantic Release
         uses: cycjimmy/semantic-release-action@v2.6.0

--- a/.github/workflows/build-test-release.yml
+++ b/.github/workflows/build-test-release.yml
@@ -98,7 +98,7 @@ jobs:
           python-version: 3.7
       - name: run tests
         run: |
-          curl -sSL https://raw.githubusercontent.com/python-poetry/poetry/master/get-poetry.py | python -
+          curl -sSL https://install.python-poetry.org | python3 -
           # shellcheck disable=SC1090
           source "$HOME/.poetry/env"
           poetry install
@@ -154,7 +154,7 @@ jobs:
           sudo /opt/splunk/bin/splunk restart
       - name: Run tests
         run: |
-          curl -sSL https://raw.githubusercontent.com/python-poetry/poetry/master/get-poetry.py | python3 -
+          curl -sSL https://install.python-poetry.org | python3 -
           # shellcheck disable=SC1090
           source "$HOME/.poetry/env"
           poetry install
@@ -217,7 +217,7 @@ jobs:
         with:
           python-version: "3.7"
       - name: Install Poetry
-        run: curl -sSL https://raw.githubusercontent.com/python-poetry/poetry/master/get-poetry.py | python3 -
+        run: curl -sSL https://install.python-poetry.org | python3 -
       - name: Install Code
         run: |
           # shellcheck disable=SC1090


### PR DESCRIPTION
From `poetry` [README](https://github.com/python-poetry/poetry#installation):

Warning: The previous get-poetry.py installer is now deprecated, if you are currently using it you should migrate to the new, supported, install-poetry.py installer.