### PR TITLE
feat: add support for ipv6 in web.settings.mgmtHostPort stanza

### DIFF
--- a/solnlib/splunkenv.py
+++ b/solnlib/splunkenv.py
@@ -184,8 +184,9 @@ def get_splunkd_access_info() -> Tuple[str, str, int]:
 
     host_port = get_conf_key_value("web", "settings", "mgmtHostPort")
     host_port = host_port.strip()
-    host = host_port.split(":")[0]
-    port = int(host_port.split(":")[1])
+    host_port_split_parts = host_port.split(":")
+    host = ":".join(host_port_split_parts[:-1])
+    port = int(host_port_split_parts[-1])
 
     if "SPLUNK_BINDIP" in os.environ:
         bindip = os.environ["SPLUNK_BINDIP"]

--- a/tests/unit/test_splunkenv.py
+++ b/tests/unit/test_splunkenv.py
@@ -15,8 +15,10 @@
 #
 
 import os
+from unittest import mock
 
 import common
+import pytest
 
 from solnlib import splunkenv
 
@@ -47,13 +49,79 @@ def test_splunk_bin(monkeypatch):
     )
 
 
-def test_get_splunkd_access_info(monkeypatch):
-    common.mock_splunkhome(monkeypatch)
+@mock.patch.object(splunkenv, "get_conf_key_value")
+@pytest.mark.parametrize(
+    "enable_splunkd_ssl,mgmt_host_port,expected_scheme,expected_host,expected_port",
+    [
+        (
+            "true",
+            "127.0.0.1:8089",
+            "https",
+            "127.0.0.1",
+            8089,
+        ),
+        (
+            "true",
+            "localhost:8089",
+            "https",
+            "localhost",
+            8089,
+        ),
+        (
+            "false",
+            "127.0.0.1:8089",
+            "http",
+            "127.0.0.1",
+            8089,
+        ),
+        (
+            "false",
+            "localhost:8089",
+            "http",
+            "localhost",
+            8089,
+        ),
+        (
+            "false",
+            "1.2.3.4:5678",
+            "http",
+            "1.2.3.4",
+            5678,
+        ),
+        (
+            "true",
+            "[::1]:8089",
+            "https",
+            "[::1]",
+            8089,
+        ),
+        (
+            "false",
+            "[::1]:8089",
+            "http",
+            "[::1]",
+            8089,
+        ),
+    ],
+)
+def test_get_splunkd_access_info(
+    mock_get_conf_key_value,
+    enable_splunkd_ssl,
+    mgmt_host_port,
+    expected_scheme,
+    expected_host,
+    expected_port,
+):
+    mock_get_conf_key_value.side_effect = [
+        enable_splunkd_ssl,
+        mgmt_host_port,
+    ]
 
     scheme, host, port = splunkenv.get_splunkd_access_info()
-    assert scheme == "https"
-    assert host == "127.0.0.1"
-    assert port == 8089
+
+    assert expected_scheme == scheme
+    assert expected_host == host
+    assert expected_port == port
 
 
 def test_splunkd_uri(monkeypatch):


### PR DESCRIPTION
It seems that you can add ipv6 string for web.settings.mgmtHostPort stanza.

Docs: https://docs.splunk.com/Documentation/Splunk/9.0.0/Admin/ConfigureSplunkforIPv6