### PR TITLE
fix(code): ADDON-58030 parse all definitions of true for splunkd scheme

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,9 @@
+# IDE related files
 *.idea
 *.DS_Store*
+.venv/
+
+# Compiled files
 __pycache__
 *.pyc
 *.pyo

--- a/solnlib/splunkenv.py
+++ b/solnlib/splunkenv.py
@@ -24,6 +24,8 @@ from configparser import ConfigParser
 from io import StringIO
 from typing import List, Optional, Tuple, Union
 
+from .utils import is_true
+
 __all__ = [
     "make_splunkhome_path",
     "get_splunk_host_info",
@@ -177,7 +179,7 @@ def get_splunkd_access_info() -> Tuple[str, str, int]:
         Tuple of (scheme, host, port).
     """
 
-    if get_conf_key_value("server", "sslConfig", "enableSplunkdSSL") == "true":
+    if is_true(get_conf_key_value("server", "sslConfig", "enableSplunkdSSL")):
         scheme = "https"
     else:
         scheme = "http"


### PR DESCRIPTION
When other values of `true` are passed in `server.conf` such as `1`, `TRUE`, `T`, the Splunkd URI was incorrectly formed, hence by using the `is_true()` function, all the values are parsed in an expected manner.