### PR TITLE
fix: sourcetype renamed to sourcetype_ingested

### DIFF
--- a/solnlib/log.py
+++ b/solnlib/log.py
@@ -259,7 +259,7 @@ def events_ingested(
         {
             "action": "events_ingested",
             "modular_input_name": modular_input_name,
-            "sourcetype": sourcetype,
+            "sourcetype_ingested": sourcetype,
             "n_events": n_events,
         },
     )

--- a/tests/unit/test_log.py
+++ b/tests/unit/test_log.py
@@ -195,5 +195,5 @@ def test_events_ingested():
 
         mock_logger.log.assert_called_once_with(
             logging.INFO,
-            "action=events_ingested modular_input_name=modular_input_name sourcetype=sourcetype n_events=5",
+            "action=events_ingested modular_input_name=modular_input_name sourcetype_ingested=sourcetype n_events=5",
         )


### PR DESCRIPTION
If we just use sourcetype, it is being shadowed by Splunk's own sourcetype field during the dashboard creation and does not properly reflect the sourcetype where the data is being ingested.