### PR TITLE
fix: require requests 2.31.0 and urllib3 < 2

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -15,6 +15,6 @@ jobs:
         with:
           python-version: 3.7
       - run: |
-          curl -sSL https://install.python-poetry.org | python3 -
+          pipx install poetry==1.4.2
           poetry install
           poetry run mkdocs gh-deploy --force

--- a/poetry.lock
+++ b/poetry.lock
@@ -778,21 +778,20 @@ files = [
 
 [[package]]
 name = "urllib3"
-version = "2.0.2"
+version = "1.26.16"
 description = "HTTP library with thread-safe connection pooling, file post, and more."
 category = "main"
 optional = false
-python-versions = ">=3.7"
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, !=3.5.*"
 files = [
-    {file = "urllib3-2.0.2-py3-none-any.whl", hash = "sha256:d055c2f9d38dc53c808f6fdc8eab7360b6fdbbde02340ed25cfbcd817c62469e"},
-    {file = "urllib3-2.0.2.tar.gz", hash = "sha256:61717a1095d7e155cdb737ac7bb2f4324a858a1e2e6466f6d03ff630ca68d3cc"},
+    {file = "urllib3-1.26.16-py2.py3-none-any.whl", hash = "sha256:8d36afa7616d8ab714608411b4a3b13e58f463aee519024578e062e141dce20f"},
+    {file = "urllib3-1.26.16.tar.gz", hash = "sha256:8f135f6502756bde6b2a9b28989df5fbe87c9970cecaa69041edcce7f0589b14"},
 ]
 
 [package.extras]
-brotli = ["brotli (>=1.0.9)", "brotlicffi (>=0.8.0)"]
-secure = ["certifi", "cryptography (>=1.9)", "idna (>=2.0.0)", "pyopenssl (>=17.1.0)", "urllib3-secure-extra"]
-socks = ["pysocks (>=1.5.6,!=1.5.7,<2.0)"]
-zstd = ["zstandard (>=0.18.0)"]
+brotli = ["brotli (>=1.0.9)", "brotlicffi (>=0.8.0)", "brotlipy (>=0.6.0)"]
+secure = ["certifi", "cryptography (>=1.3.4)", "idna (>=2.0.0)", "ipaddress", "pyOpenSSL (>=0.14)", "urllib3-secure-extra"]
+socks = ["PySocks (>=1.5.6,!=1.5.7,<2.0)"]
 
 [[package]]
 name = "watchdog"
@@ -853,4 +852,4 @@ testing = ["big-O", "flake8 (<5)", "jaraco.functools", "jaraco.itertools", "more
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.7"
-content-hash = "0e6cce14514e94c9acf8d9744b29063d281272f259b739c5582b1e7e6c8e6710"
+content-hash = "887b93a9eb08cc8ed1b113a92d9d80369652b3082da013342805bce9d8b6d299"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,8 @@ repository = "https://github.com/splunk/addonfactory-solutions-library-python"
 
 [tool.poetry.dependencies]
 python = "^3.7"
-requests = "^2.28.0"
+requests = "^2.31.0"
+urllib3 = "<2"
 sortedcontainers = "^2.2"
 defusedxml = "^0.7.1"
 splunk-sdk = ">=1.6.18"


### PR DESCRIPTION
Release a fix for https://github.com/splunk/addonfactory-solutions-library-python/security/dependabot/4.