### PR TITLE
chore: update from poetry dev-dependencies to group.dev

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ sortedcontainers = ">=2"
 defusedxml = ">=0.7"
 splunk-sdk = ">=1.6"
 
-[tool.poetry.dev-dependencies]
+[tool.poetry.group.dev.dependencies]
 pytest = ">=7"
 mkdocs = ">=1"
 mkdocs-material = ">=9"


### PR DESCRIPTION
This is a technical change to make sure we use latest poetry syntax to specify dev dependencies.