### PR TITLE
chore: change artifact name

### DIFF
--- a/.github/workflows/build-test-release.yml
+++ b/.github/workflows/build-test-release.yml
@@ -138,7 +138,7 @@ jobs:
           SPLUNK_HOME=/opt/splunk/ poetry run pytest --junitxml=test-results/results.xml -v tests/integration
       - uses: actions/upload-artifact@v4
         with:
-          name: test-splunk
+          name: test-splunk-${{ matrix.splunk.version }}-${{ matrix.python-version }}
           path: test-results
 
   publish:


### PR DESCRIPTION
fix `"an artifact with this name already exists"` error