### PR TITLE
ci: fix regex to capture only necessary version update

### DIFF
--- a/.releaserc
+++ b/.releaserc
@@ -28,7 +28,7 @@
             },
             {
               "files": ["pyproject.toml"],
-              "from": "version ?=.*",
+              "from": "version = \".*\"",
               "to": "version = \"${nextRelease.version}\"",
               "results": [
                 {


### PR DESCRIPTION
Tested in regex101.com.

It captured `mkdocstrings = {version=">=0", extras=["python"]}` as well which we don't need.

Fixes https://github.com/splunk/addonfactory-solutions-library-python/actions/runs/7713020796/job/21022116056#step:6:502