### PR TITLE
feat: extend events_ingested to accommodate UCC health check page

### DIFF
--- a/solnlib/log.py
+++ b/solnlib/log.py
@@ -256,27 +256,47 @@ def events_ingested(
     modular_input_name: str,
     sourcetype: str,
     n_events: int,
-    index: str = None,
+    index: str,
     account: str = None,
     host: str = None,
 ):
-    """Specific function to log the basic information of events ingested."""
+    """Specific function to log the basic information of events ingested for
+    the monitoring dashboard.
+
+    Arguments:
+        logger: Add-on logger.
+        modular_input_name: Full name of the modular input. It needs to be in a format <input_type>://<input_name>.
+        In case of invalid format ValueError is raised.
+        sourcetype: Source type used to write event.
+        n_events: Number of ingested events.
+        index: Index used to write event.
+        account: Account used to write event. (optional)
+        host: Host used to write event. (optional)
+    """
+
+    if "://" in modular_input_name:
+        input_name = modular_input_name.split("/")[-1]
+    else:
+        raise ValueError(
+            f"Invalid modular input name: {modular_input_name}. "
+            f"It should be in format <input_type>://<input_name>"
+        )
 
     result = {
         "action": "events_ingested",
         "modular_input_name": modular_input_name,
         "sourcetype_ingested": sourcetype,
         "n_events": n_events,
+        "event_input": input_name,
+        "event_index": index,
     }
-    if index:
-        result["event_index"] = index
+
     if account:
         result["event_account"] = account
+
     if host:
         result["event_host"] = host
-    if "://" in modular_input_name:
-        input_name = modular_input_name.split("/")[-1]
-        result["event_input"] = input_name
+
     log_event(logger, result)
 
 

--- a/solnlib/log.py
+++ b/solnlib/log.py
@@ -252,18 +252,32 @@ def modular_input_end(logger: logging.Logger, modular_input_name: str):
 
 
 def events_ingested(
-    logger: logging.Logger, modular_input_name: str, sourcetype: str, n_events: int
+    logger: logging.Logger,
+    modular_input_name: str,
+    sourcetype: str,
+    n_events: int,
+    index: str = None,
+    account: str = None,
+    host: str = None,
 ):
-    """Specific function to log the number of events ingested."""
-    log_event(
-        logger,
-        {
-            "action": "events_ingested",
-            "modular_input_name": modular_input_name,
-            "sourcetype_ingested": sourcetype,
-            "n_events": n_events,
-        },
-    )
+    """Specific function to log the basic information of events ingested."""
+
+    result = {
+        "action": "events_ingested",
+        "modular_input_name": modular_input_name,
+        "sourcetype_ingested": sourcetype,
+        "n_events": n_events,
+    }
+    if index:
+        result["event_index"] = index
+    if account:
+        result["event_account"] = account
+    if host:
+        result["event_host"] = host
+    if "://" in modular_input_name:
+        input_name = modular_input_name.split("/")[-1]
+        result["event_input"] = input_name
+    log_event(logger, result)
 
 
 def log_exception(

--- a/tests/unit/test_log.py
+++ b/tests/unit/test_log.py
@@ -22,6 +22,7 @@ import shutil
 import threading
 import traceback
 import time
+import pytest
 from unittest import mock
 
 from solnlib import log
@@ -193,11 +194,14 @@ def test_modular_input_end():
 
 def test_events_ingested():
     with mock.patch("logging.Logger") as mock_logger:
-        log.events_ingested(mock_logger, "modular_input_name", "sourcetype", 5)
+        log.events_ingested(
+            mock_logger, "input_type://input_name", "sourcetype", 5, "default"
+        )
 
         mock_logger.log.assert_called_once_with(
             logging.INFO,
-            "action=events_ingested modular_input_name=modular_input_name sourcetype_ingested=sourcetype n_events=5",
+            "action=events_ingested modular_input_name=input_type://input_name sourcetype_ingested=sourcetype "
+            "n_events=5 event_input=input_name event_index=default",
         )
 
     with mock.patch("logging.Logger") as mock_logger:
@@ -206,7 +210,7 @@ def test_events_ingested():
             "demo://modular_input_name",
             "sourcetype",
             5,
-            index="default",
+            "default",
             host="abcd",
             account="test_acc",
         )
@@ -214,25 +218,26 @@ def test_events_ingested():
         mock_logger.log.assert_called_once_with(
             logging.INFO,
             "action=events_ingested modular_input_name=demo://modular_input_name sourcetype_ingested=sourcetype n_"
-            "events=5 event_index=default event_account=test_acc event_host=abcd event_input=modular_input_name",
+            "events=5 event_input=modular_input_name event_index=default event_account=test_acc event_host=abcd",
         )
 
-    with mock.patch("logging.Logger") as mock_logger:
-        log.events_ingested(
-            mock_logger,
-            "modular_input_name",
-            "sourcetype",
-            5,
-            index="default",
-            host="abcd",
-            account="test_acc",
-        )
 
-        mock_logger.log.assert_called_once_with(
-            logging.INFO,
-            "action=events_ingested modular_input_name=modular_input_name sourcetype_ingested=sourcetype n_"
-            "events=5 event_index=default event_account=test_acc event_host=abcd",
-        )
+def test_events_ingested_invalid_input():
+    exp_msg = "Invalid modular input name: modular_input_name. It should be in format <input_type>://<input_name>"
+
+    with pytest.raises(ValueError) as excinfo:
+        with mock.patch("logging.Logger") as mock_logger:
+            log.events_ingested(
+                mock_logger,
+                "modular_input_name",
+                "sourcetype",
+                5,
+                "default",
+                host="abcd",
+                account="test_acc",
+            )
+
+    assert exp_msg == str(excinfo.value)
 
 
 def test_log_exceptions_full_msg():

--- a/tests/unit/test_log.py
+++ b/tests/unit/test_log.py
@@ -200,6 +200,40 @@ def test_events_ingested():
             "action=events_ingested modular_input_name=modular_input_name sourcetype_ingested=sourcetype n_events=5",
         )
 
+    with mock.patch("logging.Logger") as mock_logger:
+        log.events_ingested(
+            mock_logger,
+            "demo://modular_input_name",
+            "sourcetype",
+            5,
+            index="default",
+            host="abcd",
+            account="test_acc",
+        )
+
+        mock_logger.log.assert_called_once_with(
+            logging.INFO,
+            "action=events_ingested modular_input_name=demo://modular_input_name sourcetype_ingested=sourcetype n_"
+            "events=5 event_index=default event_account=test_acc event_host=abcd event_input=modular_input_name",
+        )
+
+    with mock.patch("logging.Logger") as mock_logger:
+        log.events_ingested(
+            mock_logger,
+            "modular_input_name",
+            "sourcetype",
+            5,
+            index="default",
+            host="abcd",
+            account="test_acc",
+        )
+
+        mock_logger.log.assert_called_once_with(
+            logging.INFO,
+            "action=events_ingested modular_input_name=modular_input_name sourcetype_ingested=sourcetype n_"
+            "events=5 event_index=default event_account=test_acc event_host=abcd",
+        )
+
 
 def test_log_exceptions_full_msg():
     start_msg = "some msg before exception"


### PR DESCRIPTION
Extended the `events_ingested` function to log more information such as index, host, account and input.