### PR TITLE
feat: BaseScript class that loads scheme parameter from json

### DIFF
--- a/solnlib/modular_input/__init__.py
+++ b/solnlib/modular_input/__init__.py
@@ -18,6 +18,7 @@
 
 from splunklib.modularinput.argument import Argument
 
+from .base_script import BaseScript
 from .checkpointer import CheckpointerException, FileCheckpointer, KVStoreCheckpointer
 from .event import EventException, HECEvent, XMLEvent
 from .event_writer import ClassicEventWriter, HECEventWriter
@@ -35,4 +36,5 @@ __all__ = [
     "Argument",
     "ModularInputException",
     "ModularInput",
+    "BaseScript",
 ]

--- a/solnlib/modular_input/base_script.py
+++ b/solnlib/modular_input/base_script.py
@@ -23,8 +23,8 @@ from splunklib import modularinput as smi
 
 
 class BaseScript(smi.Script, ABC):
-    """
-    A class that by default takes scheme parameters from (...).args.json files.
+    """A class that by default takes scheme parameters from (...).args.json
+    files.
 
     For example, if the subclass is located in example.py, it will take parameters from example.args.json.
 
@@ -39,6 +39,7 @@ class BaseScript(smi.Script, ABC):
             ]
         ]
     """
+
     def get_scheme(self):
         scheme = smi.Scheme(self.args.get("name"))
         scheme.description = self.args.get("description")
@@ -48,10 +49,7 @@ class BaseScript(smi.Script, ABC):
 
         scheme.add_argument(
             smi.Argument(
-                'name',
-                title='Name',
-                description='Name',
-                required_on_create=True
+                "name", title="Name", description="Name", required_on_create=True
             )
         )
 

--- a/solnlib/modular_input/base_script.py
+++ b/solnlib/modular_input/base_script.py
@@ -1,0 +1,84 @@
+#
+# Copyright 2024 Splunk Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import importlib
+import json
+import os.path
+from abc import ABC
+
+from splunklib import modularinput as smi
+
+
+class BaseScript(smi.Script, ABC):
+    """
+    A class that by default takes scheme parameters from (...).args.json files.
+
+    For example, if the subclass is located in example.py, it will take parameters from example.args.json.
+
+    Example content of (...).args.json:
+        {
+            "name": "...",
+            "description": "...",
+            "entity": [
+                {
+                    "field": "some_field"
+                }
+            ]
+        ]
+    """
+    def get_scheme(self):
+        scheme = smi.Scheme(self.args.get("name"))
+        scheme.description = self.args.get("description")
+        scheme.use_external_validation = self.args.get("use_external_validation", True)
+        scheme.streaming_mode_xml = self.args.get("streaming_mode_xml", True)
+        scheme.use_single_instance = self.args.get("use_single_instance", False)
+
+        scheme.add_argument(
+            smi.Argument(
+                'name',
+                title='Name',
+                description='Name',
+                required_on_create=True
+            )
+        )
+
+        for entity in self._args.get("entity", []):
+            scheme.add_argument(
+                smi.Argument(
+                    entity["field"],
+                    required_on_create=entity.get("required", False),
+                )
+            )
+
+        return scheme
+
+    @property
+    def args(self):
+        if not hasattr(self, "_args"):
+            self._args = self._load_args()
+
+        return self._args
+
+    def _load_args(self):
+        subcls_module = importlib.import_module(self.__module__)
+        path_split = os.path.splitext(subcls_module.__file__)[0]
+        args_file = "%s.args.json" % path_split
+
+        if not os.path.isfile(args_file):
+            return {}
+
+        with open(args_file) as fp:
+            return json.load(fp)

--- a/tests/integration/test_base_script.py
+++ b/tests/integration/test_base_script.py
@@ -1,0 +1,43 @@
+import json
+import subprocess
+import sys
+from textwrap import dedent
+
+
+def test_base_script(tmp_path):
+    args = {
+        "name": "example_script",
+        "description": "Example description",
+        "entity": [
+            {
+                "field": "some_field1",
+                "required": True
+            },
+            {
+                "field": "some_field2"
+            }
+        ]
+    }
+
+    with open(tmp_path / "some_script.args.json", "w") as fp:
+        json.dump(args, fp)
+
+    with open(tmp_path / "some_script.py", "w") as fp:
+        fp.write(dedent(
+            """
+            import json
+            from solnlib.modular_input import BaseScript
+            
+            
+            class SomeScript(BaseScript):
+                def stream_events(self, inputs, ew):
+                    pass
+            
+            
+            print(json.dumps(SomeScript().args))
+            """
+        ))
+
+    proc = subprocess.Popen([sys.executable, str(tmp_path / "some_script.py")], stdout=subprocess.PIPE)
+    stdout = proc.communicate()[0].decode()
+    assert json.loads(stdout) == args

--- a/tests/integration/test_base_script.py
+++ b/tests/integration/test_base_script.py
@@ -9,35 +9,34 @@ def test_base_script(tmp_path):
         "name": "example_script",
         "description": "Example description",
         "entity": [
-            {
-                "field": "some_field1",
-                "required": True
-            },
-            {
-                "field": "some_field2"
-            }
-        ]
+            {"field": "some_field1", "required": True},
+            {"field": "some_field2"},
+        ],
     }
 
     with open(tmp_path / "some_script.args.json", "w") as fp:
         json.dump(args, fp)
 
     with open(tmp_path / "some_script.py", "w") as fp:
-        fp.write(dedent(
-            """
+        fp.write(
+            dedent(
+                """
             import json
             from solnlib.modular_input import BaseScript
-            
-            
+
+
             class SomeScript(BaseScript):
                 def stream_events(self, inputs, ew):
                     pass
-            
-            
+
+
             print(json.dumps(SomeScript().args))
             """
-        ))
+            )
+        )
 
-    proc = subprocess.Popen([sys.executable, str(tmp_path / "some_script.py")], stdout=subprocess.PIPE)
+    proc = subprocess.Popen(
+        [sys.executable, str(tmp_path / "some_script.py")], stdout=subprocess.PIPE
+    )
     stdout = proc.communicate()[0].decode()
     assert json.loads(stdout) == args

--- a/tests/unit/test_base_script.py
+++ b/tests/unit/test_base_script.py
@@ -52,14 +52,9 @@ def args_content():
         "name": "example_script",
         "description": "Example description",
         "entity": [
-            {
-                "field": "some_field1",
-                "required": True
-            },
-            {
-                "field": "some_field2"
-            }
-        ]
+            {"field": "some_field1", "required": True},
+            {"field": "some_field2"},
+        ],
     }
 
 
@@ -102,7 +97,9 @@ def test_base_script_scheme(args_content, example_script):
     assert scheme.arguments[0].required_on_create
 
     assert scheme.arguments[1].name == args_content["entity"][0]["field"]
-    assert scheme.arguments[1].required_on_create == args_content["entity"][0]["required"]
+    assert (
+        scheme.arguments[1].required_on_create is args_content["entity"][0]["required"]
+    )
 
     assert scheme.arguments[2].name == args_content["entity"][1]["field"]
-    assert scheme.arguments[2].required_on_create == False
+    assert not scheme.arguments[2].required_on_create

--- a/tests/unit/test_base_script.py
+++ b/tests/unit/test_base_script.py
@@ -1,0 +1,108 @@
+import builtins
+import json
+import os
+from io import StringIO
+
+import pytest
+
+from solnlib.modular_input import BaseScript
+
+
+@pytest.fixture()
+def file_open_mock(args_content, args_path, monkeypatch):
+    _old_open = open
+
+    def _open_mocked(*args, **kwargs):
+        if args[0] == args_path:
+            return StringIO(json.dumps(args_content))
+        return _old_open(*args, **kwargs)
+
+    monkeypatch.setattr(builtins, "open", _open_mocked)
+
+
+@pytest.fixture()
+def file_exists_mock(monkeypatch, args_path):
+    _old_isfile = os.path.isfile
+
+    def _isfile_mocked(*args, **kwargs):
+        if args[0] == args_path:
+            return True
+        return _old_isfile(*args, **kwargs)
+
+    monkeypatch.setattr(os.path, "isfile", _isfile_mocked)
+
+
+@pytest.fixture()
+def example_script():
+    class ExampleScript(BaseScript):
+        def stream_events(self, inputs, ew):
+            pass
+
+    return ExampleScript()
+
+
+@pytest.fixture
+def args_path():
+    return os.path.splitext(__file__)[0] + ".args.json"
+
+
+@pytest.fixture
+def args_content():
+    return {
+        "name": "example_script",
+        "description": "Example description",
+        "entity": [
+            {
+                "field": "some_field1",
+                "required": True
+            },
+            {
+                "field": "some_field2"
+            }
+        ]
+    }
+
+
+@pytest.mark.usefixtures("file_exists_mock", "file_open_mock")
+def test_base_script_args_file_exists(args_content, example_script):
+    assert example_script.args == args_content
+
+
+def test_base_script_args_file_does_not_exist(example_script):
+    assert example_script.args == {}
+
+
+@pytest.mark.usefixtures("file_exists_mock")
+def test_base_script_args_cached(example_script, args_content, monkeypatch, args_path):
+    data = {"calls": 0}
+    _old_open = open
+
+    def _open_mocked(*args, **kwargs):
+        if args[0] == args_path:
+            data["calls"] += 1
+            return StringIO(json.dumps(args_content))
+        return _old_open(*args, **kwargs)
+
+    monkeypatch.setattr(builtins, "open", _open_mocked)
+
+    assert data["calls"] == 0
+    assert example_script.args == args_content
+    assert data["calls"] == 1
+    assert example_script.args == args_content
+    assert data["calls"] == 1
+
+
+@pytest.mark.usefixtures("file_exists_mock", "file_open_mock")
+def test_base_script_scheme(args_content, example_script):
+    scheme = example_script.get_scheme()
+    assert scheme.title == args_content["name"]
+    assert scheme.description == args_content["description"]
+    assert len(scheme.arguments) == 3
+    assert scheme.arguments[0].name == "name"
+    assert scheme.arguments[0].required_on_create
+
+    assert scheme.arguments[1].name == args_content["entity"][0]["field"]
+    assert scheme.arguments[1].required_on_create == args_content["entity"][0]["required"]
+
+    assert scheme.arguments[2].name == args_content["entity"][1]["field"]
+    assert scheme.arguments[2].required_on_create == False


### PR DESCRIPTION
Solution inspired by [this](https://github.com/splunk/splunk-add-on-for-salesforce/blob/v4.2.0/package/lib/modinput_wrapper/base_modinput.py).

This class by default looks for a json file next to the subclass, in order to get scheme parameters.

For example if we have a subclass ExampleInput in `example_input.py`, it will try to take parameters from `example_input.args.json`. Of course `get_scheme` can be overriden.

The json file will be generated by UCC based on `globalConfig.json`.