### PR TITLE
fix(log_level): update fetching loglevel with stanza

### DIFF
--- a/solnlib/conf_manager.py
+++ b/solnlib/conf_manager.py
@@ -506,6 +506,7 @@ def get_log_level(
     session_key: str,
     app_name: str,
     conf_name: str,
+    log_stanza: str = "logging",
     log_level_field: str = "loglevel",
     default_log_level: str = "INFO",
 ) -> str:
@@ -517,6 +518,7 @@ def get_log_level(
         session_key: Splunk access token.
         app_name: Add-on name.
         conf_name: Configuration file name where logging stanza is.
+        log_stanza: Logging stanza to define `log_level_field` and its value.
         log_level_field: Logging level field name under logging stanza.
         default_log_level: Default log level to return in case of errors.
 
@@ -547,7 +549,7 @@ def get_log_level(
         )
         return default_log_level
     try:
-        logging_details = conf.get("logging")
+        logging_details = conf.get(log_stanza)
         return logging_details.get(log_level_field, default_log_level)
     except ConfStanzaNotExistException:
         logger.error(

--- a/tests/unit/test_conf_manager.py
+++ b/tests/unit/test_conf_manager.py
@@ -32,3 +32,60 @@ def test_get_log_level_when_error_getting_conf(mock_conf_manager_class):
     )
 
     assert expected_log_level == log_level
+
+
+@mock.patch.object(conf_manager, "ConfManager")
+def test_get_log_level_with_custom_values(mock_conf_manager_class):
+    mock_conf_manager = mock_conf_manager_class.return_value
+    mock_conf_manager.get_conf.return_value = {"my_logger": {"my_field": "DEBUG"}}
+    expected_log_level = "DEBUG"
+
+    log_level = conf_manager.get_log_level(
+        logger=mock.MagicMock(),
+        session_key="session_key",
+        app_name="app_name",
+        conf_name="conf_name",
+        log_stanza="my_logger",
+        log_level_field="my_field",
+    )
+
+    assert log_level == expected_log_level
+
+
+@mock.patch.object(conf_manager, "ConfManager")
+def test_get_log_level_with_no_logging_stanza(mock_conf_manager_class):
+    mock_conf_manager = mock_conf_manager_class.return_value
+    mock_conf_manager.get_conf.return_value = mock.MagicMock()
+    mock_conf_manager.get_conf.return_value.get.side_effect = (
+        conf_manager.ConfStanzaNotExistException
+    )
+    logger = mock.MagicMock()
+    expected_log_level = "INFO"
+
+    log_level = conf_manager.get_log_level(
+        logger=logger,
+        session_key="session_key",
+        app_name="app_name",
+        conf_name="conf_name",
+        log_stanza="my_logger",
+        log_level_field="my_field",
+    )
+
+    assert log_level == expected_log_level
+    assert logger.error.call_count == 1
+
+
+@mock.patch.object(conf_manager, "ConfManager")
+def test_get_log_level_with_default_fields(mock_conf_manager_class):
+    mock_conf_manager = mock_conf_manager_class.return_value
+    mock_conf_manager.get_conf.return_value = {"logging": {"loglevel": "WARN"}}
+    expected_log_level = "WARN"
+
+    log_level = conf_manager.get_log_level(
+        logger=mock.MagicMock(),
+        session_key="session_key",
+        app_name="app_name",
+        conf_name="conf_name",
+    )
+
+    assert log_level == expected_log_level


### PR DESCRIPTION
Allow developers to pass their logging stanza name while getting the log level via `conf_manager.py`.