### PR TITLE
feat: add bulletin_rest_client module to manage global Splunk messages

### DIFF
--- a/docs/bulletin_rest_client.md
+++ b/docs/bulletin_rest_client.md
@@ -1,0 +1,1 @@
+::: solnlib.bulletin_rest_client

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -41,6 +41,7 @@ nav:
       - "pattern.py": pattern.md
       - "server_info.py": server_info.md
       - "splunk_rest_client.py": splunk_rest_client.md
+      - "bulletin_rest_client.py": bulletin_rest_client.md
       - "splunkenv.py": splunkenv.md
       - "time_parser.py": time_parser.md
       - "timer_queue.py": timer_queue.md

--- a/solnlib/__init__.py
+++ b/solnlib/__init__.py
@@ -18,6 +18,7 @@
 
 from . import (
     acl,
+    bulletin_rest_client,
     conf_manager,
     credentials,
     file_monitor,
@@ -37,6 +38,7 @@ from . import (
 
 __all__ = [
     "acl",
+    "bulletin_rest_client",
     "conf_manager",
     "credentials",
     "file_monitor",

--- a/solnlib/bulletin_rest_client.py
+++ b/solnlib/bulletin_rest_client.py
@@ -15,7 +15,6 @@
 #
 
 from solnlib import splunk_rest_client as rest_client
-from splunklib import binding
 from typing import Optional, List
 import json
 
@@ -102,7 +101,11 @@ class BulletinRestClient:
             "role": [],
         }
 
-        if severity not in (self.Severity.INFO, self.Severity.WARNING, self.Severity.ERROR):
+        if severity not in (
+            self.Severity.INFO,
+            self.Severity.WARNING,
+            self.Severity.ERROR,
+        ):
             raise ValueError("Severity must be one of ('info', 'warn', 'error').")
 
         if capabilities:

--- a/solnlib/bulletin_rest_client.py
+++ b/solnlib/bulletin_rest_client.py
@@ -41,7 +41,6 @@ class BulletinRestClient:
         **context: dict,
     ):
         """Initializes BulletinRestClient.
-
             When creating a new bulletin message, you must provide a name, which is a kind of ID.
             If you try to create another message with the same name (ID), the API will not add another message
             to the bulletin, but it will overwrite the existing one. Similar behaviour applies to deletion.
@@ -55,7 +54,7 @@ class BulletinRestClient:
             msg_2 = BulletinRestClient("message_2", "<some session key>")
 
         Arguments:
-            message_name: Name of the message in the splunk's bulletin.
+            message_name: Name of the message in the Splunk's bulletin.
             session_key: Splunk access token.
             app: App name of namespace.
             context: Other configurations for Splunk rest client.
@@ -76,13 +75,13 @@ class BulletinRestClient:
         capabilities: Optional[List[str]] = None,
         roles: Optional[List] = None,
     ):
-        """Creates a message in the splunk's bulletin. Calling this method
+        """Creates a message in the Splunk's bulletin. Calling this method
         multiple times for the same instance will overwrite existing message.
 
         Arguments:
-            msg: The message which will be displayed in the splunk's bulletin'
+            msg: The message which will be displayed in the Splunk's bulletin
             severity: Severity level of the message. It has to be one of: 'info', 'warn', 'error'.
-            If wrong severity is given, ValueError will be raised.
+                If wrong severity is given, ValueError will be raised.
             capabilities: One or more capabilities that users must have to view the message.
                 Capability names are validated.
                 This argument should be provided as a list of string/s e.g. capabilities=['one', 'two'].

--- a/solnlib/bulletin_rest_client.py
+++ b/solnlib/bulletin_rest_client.py
@@ -1,0 +1,104 @@
+import logging
+from solnlib import splunk_rest_client as rest_client
+from splunklib import binding
+import json
+
+
+__all__ = ["BulletinRestClient"]
+
+
+class BulletinRestClient:
+    READ_ENDPOINT = "/services/admin/messages"
+    CREATE_DELETE_ENDPOINT = "/services/messages"
+
+    headers = [("Content-Type", "application/json")]
+
+    def __init__(
+        self,
+        message_name: str,
+        session_key: str,
+        logger: logging.Logger = None,
+        **context: dict,
+    ):
+
+        self.message_name = message_name
+        self.session_key = session_key
+
+        if logger:
+            self.logger = logger
+        else:
+            self.logger = logging
+
+        self._rest_client = rest_client.SplunkRestClient(
+            self.session_key, app="-", **context
+        )
+        self.logger.info(f"mymy123 init {self.message_name}")
+
+    def create_message(self, msg):
+        body = {"name": self.message_name, "value": msg}
+        self.logger.info(f"mymy123 create_message {self.message_name} {msg}")
+        try:
+            self._rest_client.post(
+                self.CREATE_DELETE_ENDPOINT, body=body, headers=self.headers
+            )
+        except binding.HTTPError as e:
+            if 400 <= e.status < 500:
+                self.logger.error(
+                    f"Create message failed - {e.status} "
+                    f"Client Error: {e.reason} for url: {self.CREATE_DELETE_ENDPOINT}"
+                )
+            if 500 <= e.status < 600:
+                self.logger.error(
+                    f"Create message failed - {e.status} "
+                    f"Server Error: {e.reason} for url: {self.CREATE_DELETE_ENDPOINT}"
+                )
+
+    def get_message(self):
+        endpoint = f"{self.READ_ENDPOINT}/{self.message_name}"
+        self.logger.info(f"mymy123 get_message {self.message_name} url {endpoint}")
+        try:
+            response = self._rest_client.get(endpoint, output_mode="json").body.read()
+            return json.loads(response)
+        except binding.HTTPError as e:
+            if 400 <= e.status < 500:
+                self.logger.error(
+                    f"Get message failed - {e.status} Client Error: {e.reason} for url: {endpoint}"
+                )
+            if 500 <= e.status < 600:
+                self.logger.error(
+                    f"Get message failed - {e.status} Server Error: {e.reason} for url: {endpoint}"
+                )
+
+    def get_all_messages(self):
+        self.logger.info(
+            f"mymy123 get all message {self.message_name} url {self.READ_ENDPOINT}"
+        )
+        try:
+            response = self._rest_client.get(
+                self.READ_ENDPOINT, output_mode="json"
+            ).body.read()
+            return json.loads(response)
+        except binding.HTTPError as e:
+            if 400 <= e.status < 500:
+                self.logger.error(
+                    f"Get all messages failed - {e.status} Client Error: {e.reason} for url: {self.READ_ENDPOINT}"
+                )
+            if 500 <= e.status < 600:
+                self.logger.error(
+                    f"Get all messages failed - {e.status} Server Error: {e.reason} for url: {self.READ_ENDPOINT}"
+                )
+
+    def delete_message(self):
+        endpoint = f"{self.CREATE_DELETE_ENDPOINT}/{self.message_name}"
+        self.logger.info(f"mymy123 delete message {self.message_name} url {endpoint}")
+        try:
+            self._rest_client.delete(endpoint)
+        except binding.HTTPError as e:
+            if 400 <= e.status < 500:
+                self.logger.error(
+                    f"Delete message failed - {e.status} Client Error: {e.reason} for url: {endpoint}"
+                )
+            if 500 <= e.status < 600:
+                self.logger.error(
+                    f"Delete message failed - {e.status} Server Error: {e.reason} for url: {endpoint}"
+                )

--- a/solnlib/bulletin_rest_client.py
+++ b/solnlib/bulletin_rest_client.py
@@ -14,76 +14,120 @@
 # limitations under the License.
 #
 
-import logging
+from collections import namedtuple
 from solnlib import splunk_rest_client as rest_client
 from splunklib import binding
-from typing import Optional
+from typing import Optional, List
 import json
-
 
 __all__ = ["BulletinRestClient"]
 
 
 class BulletinRestClient:
-    READ_ENDPOINT = "/services/admin/messages"
-    CREATE_DELETE_ENDPOINT = "/services/messages"
+    """REST client for handling Bulletin messages"""
+    MESSAGES_ENDPOINT = "/services/messages"
 
     headers = [("Content-Type", "application/json")]
 
-    class LogLevel:
-        INFO = "info"
-        WARNING = "warn"
-        ERROR = "error"
+    class Severity:
+        INFO = 'info'
+        WARNING = 'warn'
+        ERROR = 'error'
 
     def __init__(
-        self,
-        message_name: str,
-        session_key: str,
-        logger: Optional[logging.Logger] = None,
-        **context: dict,
+            self,
+            message_name: str,
+            session_key: str,
+            **context: dict,
     ):
+        """Initializes BulletinRestClient.
+
+            One instance is responsible for handling one, particular message.
+            If you need to add another message to bulletin create another instance
+            with a different 'message_name'
+            e.g.
+            msg_1 = BulletinRestClient("message_1", "<some session key>")
+            msg_2 = BulletinRestClient("message_2", "<some session key>")
+
+        Arguments:
+            message_name: Name of the message in the splunk's bulletin.
+            session_key: Splunk access token.
+            context: Other configurations for Splunk rest client.
+        """
 
         self.message_name = message_name
         self.session_key = session_key
-
-        if logger:
-            self.logger = logger
-        else:
-            self.logger = logging
 
         self._rest_client = rest_client.SplunkRestClient(
             self.session_key, app="-", **context
         )
 
-    def create_message(self, msg: str, msg_lvl: LogLevel = LogLevel.WARNING):
-        body = {"name": self.message_name, "value": msg, "severity": msg_lvl}
+    def create_message(
+            self,
+            msg: str,
+            severity: Severity = Severity.WARNING,
+            capabilities: Optional[List[str]] = None,
+            roles: Optional[List] = None
+    ):
+        """
+        Creates a message in the splunk's bulletin.'
+        Calling this method multiple times for the same instance will overwrite existing message.
+
+        Arguments:
+            msg: The message which will be displayed in the splunk's bulletin'
+            severity: Severity level of the message. It has to be one of: 'info', 'warn', 'error'.
+            If wrong severity is given, ValueError will be raised.
+            capabilities: One or more capabilities that users must have to view the message.
+                Capability names are validated.
+                This argument should be provided as a list of string/s e.g. capabilities=['one', 'two'].
+                If a non-existent capability is used, HTTP 400 BAD REQUEST exception will be raised.
+                If argument is not a List[str] ValueError will be raised.
+            roles: One or more roles that users must have to view the message. Role names are validated.
+                This argument should be provided as a list of string/s e.g. roles=['user', 'admin'].
+                If a non-existent role is used, HTTP 400 BAD REQUEST exception will be raised.
+                If argument is not a List[str] ValueError will be raised.
+        """
+        body = {"name": self.message_name, "value": msg, "severity": severity, "capability": [], "role": []}
+
+        if severity not in ("info", "warn", "error"):
+            raise ValueError("Severity must be one of ('info', 'warn', 'error').")
+
+        if capabilities:
+            body["capability"] = self._validate_and_get_body_value(
+                capabilities, "Capabilities must be a list of strings."
+            )
+
+        if roles:
+            body["role"] = self._validate_and_get_body_value(
+                roles, "Roles must be a list of strings."
+            )
+
         try:
             self._rest_client.post(
-                self.CREATE_DELETE_ENDPOINT, body=body, headers=self.headers
+                self.MESSAGES_ENDPOINT, body=body, headers=self.headers
             )
         except binding.HTTPError:
             raise
 
     def get_message(self):
-        endpoint = f"{self.READ_ENDPOINT}/{self.message_name}"
-        try:
-            response = self._rest_client.get(endpoint, output_mode="json").body.read()
-            return json.loads(response)
-        except binding.HTTPError:
-            raise
+        """Get specific message created by this instance"""
+        endpoint = f"{self.MESSAGES_ENDPOINT}/{self.message_name}"
+        response = self._rest_client.get(endpoint, output_mode="json").body.read()
+        return json.loads(response)
 
     def get_all_messages(self):
-        try:
-            response = self._rest_client.get(
-                self.READ_ENDPOINT, output_mode="json"
-            ).body.read()
-            return json.loads(response)
-        except binding.HTTPError:
-            raise
+        """Get all messages in the bulletin"""
+        response = self._rest_client.get(self.MESSAGES_ENDPOINT, output_mode="json").body.read()
+        return json.loads(response)
 
     def delete_message(self):
-        endpoint = f"{self.CREATE_DELETE_ENDPOINT}/{self.message_name}"
-        try:
-            self._rest_client.delete(endpoint)
-        except binding.HTTPError:
-            raise
+        """Delete specific message created by this instance"""
+        endpoint = f"{self.MESSAGES_ENDPOINT}/{self.message_name}"
+        self._rest_client.delete(endpoint)
+
+    @staticmethod
+    def _validate_and_get_body_value(arg, error_msg) -> List:
+        if type(arg) is list and (all(isinstance(el, str) for el in arg)):
+            return [el for el in arg]
+        else:
+            raise ValueError(error_msg)

--- a/solnlib/bulletin_rest_client.py
+++ b/solnlib/bulletin_rest_client.py
@@ -106,7 +106,13 @@ class BulletinRestClient:
             self.Severity.WARNING,
             self.Severity.ERROR,
         ):
-            raise ValueError("Severity must be one of ('info', 'warn', 'error').")
+            raise ValueError(
+                "Severity must be one of ("
+                "'BulletinRestClient.Severity.INFO', "
+                "'BulletinRestClient.Severity.WARNING', "
+                "'BulletinRestClient.Severity.ERROR'"
+                ")."
+            )
 
         if capabilities:
             body["capability"] = self._validate_and_get_body_value(

--- a/solnlib/bulletin_rest_client.py
+++ b/solnlib/bulletin_rest_client.py
@@ -55,7 +55,7 @@ class BulletinRestClient:
             self.session_key, app="-", **context
         )
 
-    def create_message(self, msg, msg_lvl=LogLevel.WARNING):
+    def create_message(self, msg: str, msg_lvl: LogLevel = LogLevel.WARNING):
         body = {"name": self.message_name, "value": msg, "severity": msg_lvl}
         try:
             self._rest_client.post(

--- a/solnlib/bulletin_rest_client.py
+++ b/solnlib/bulletin_rest_client.py
@@ -14,7 +14,6 @@
 # limitations under the License.
 #
 
-from collections import namedtuple
 from solnlib import splunk_rest_client as rest_client
 from splunklib import binding
 from typing import Optional, List
@@ -24,21 +23,22 @@ __all__ = ["BulletinRestClient"]
 
 
 class BulletinRestClient:
-    """REST client for handling Bulletin messages"""
+    """REST client for handling Bulletin messages."""
+
     MESSAGES_ENDPOINT = "/services/messages"
 
     headers = [("Content-Type", "application/json")]
 
     class Severity:
-        INFO = 'info'
-        WARNING = 'warn'
-        ERROR = 'error'
+        INFO = "info"
+        WARNING = "warn"
+        ERROR = "error"
 
     def __init__(
-            self,
-            message_name: str,
-            session_key: str,
-            **context: dict,
+        self,
+        message_name: str,
+        session_key: str,
+        **context: dict,
     ):
         """Initializes BulletinRestClient.
 
@@ -63,15 +63,14 @@ class BulletinRestClient:
         )
 
     def create_message(
-            self,
-            msg: str,
-            severity: Severity = Severity.WARNING,
-            capabilities: Optional[List[str]] = None,
-            roles: Optional[List] = None
+        self,
+        msg: str,
+        severity: Severity = Severity.WARNING,
+        capabilities: Optional[List[str]] = None,
+        roles: Optional[List] = None,
     ):
-        """
-        Creates a message in the splunk's bulletin.'
-        Calling this method multiple times for the same instance will overwrite existing message.
+        """Creates a message in the splunk's bulletin.' Calling this method
+        multiple times for the same instance will overwrite existing message.
 
         Arguments:
             msg: The message which will be displayed in the splunk's bulletin'
@@ -87,7 +86,13 @@ class BulletinRestClient:
                 If a non-existent role is used, HTTP 400 BAD REQUEST exception will be raised.
                 If argument is not a List[str] ValueError will be raised.
         """
-        body = {"name": self.message_name, "value": msg, "severity": severity, "capability": [], "role": []}
+        body = {
+            "name": self.message_name,
+            "value": msg,
+            "severity": severity,
+            "capability": [],
+            "role": [],
+        }
 
         if severity not in ("info", "warn", "error"):
             raise ValueError("Severity must be one of ('info', 'warn', 'error').")
@@ -110,18 +115,20 @@ class BulletinRestClient:
             raise
 
     def get_message(self):
-        """Get specific message created by this instance"""
+        """Get specific message created by this instance."""
         endpoint = f"{self.MESSAGES_ENDPOINT}/{self.message_name}"
         response = self._rest_client.get(endpoint, output_mode="json").body.read()
         return json.loads(response)
 
     def get_all_messages(self):
-        """Get all messages in the bulletin"""
-        response = self._rest_client.get(self.MESSAGES_ENDPOINT, output_mode="json").body.read()
+        """Get all messages in the bulletin."""
+        response = self._rest_client.get(
+            self.MESSAGES_ENDPOINT, output_mode="json"
+        ).body.read()
         return json.loads(response)
 
     def delete_message(self):
-        """Delete specific message created by this instance"""
+        """Delete specific message created by this instance."""
         endpoint = f"{self.MESSAGES_ENDPOINT}/{self.message_name}"
         self._rest_client.delete(endpoint)
 

--- a/tests/integration/test_bulletin_rest_client.py
+++ b/tests/integration/test_bulletin_rest_client.py
@@ -24,6 +24,7 @@ def _build_bulletin_manager(msg_name, session_key: str) -> brc.BulletinRestClien
     return brc.BulletinRestClient(
         msg_name,
         session_key,
+        "-",
         owner=context.owner,
         scheme=context.scheme,
         host=context.host,

--- a/tests/integration/test_bulletin_rest_client.py
+++ b/tests/integration/test_bulletin_rest_client.py
@@ -1,0 +1,81 @@
+#
+# Copyright 2024 Splunk Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import context
+from splunklib import binding
+import pytest
+from solnlib import bulletin_rest_client as brc
+
+
+def _build_bulletin_manager(msg_name, session_key: str) -> brc.BulletinRestClient:
+    return brc.BulletinRestClient(
+        msg_name,
+        session_key,
+        None,
+        owner=context.owner,
+        scheme=context.scheme,
+        host=context.host,
+        port=context.port,
+    )
+
+
+def test_bulletin_rest_api():
+    session_key = context.get_session_key()
+    bulletin_client_1 = _build_bulletin_manager("msg_name_1", session_key)
+    bulletin_client_2 = _build_bulletin_manager("msg_name_2", session_key)
+
+    bulletin_client_1.create_message("new message to bulletin")
+
+    get_msg_1 = bulletin_client_1.get_message()
+    assert get_msg_1["entry"][0]["content"]["message"] == "new message to bulletin"
+    assert get_msg_1["entry"][0]["content"]["severity"] == "warn"
+
+    bulletin_client_1.create_message("new message to bulletin", bulletin_client_1.LogLevel.INFO)
+    get_msg_1 = bulletin_client_1.get_message()
+    assert get_msg_1["entry"][0]["content"]["severity"] == "info"
+
+    bulletin_client_1.create_message("new message to bulletin", bulletin_client_1.LogLevel.ERROR)
+    get_msg_1 = bulletin_client_1.get_message()
+    assert get_msg_1["entry"][0]["content"]["severity"] == "error"
+
+    get_all_msg = bulletin_client_1.get_all_messages()
+    assert len(get_all_msg["entry"]) == 1
+
+    bulletin_client_2.create_message("new message to bulletin 2")
+
+    get_msg_2 = bulletin_client_2.get_message()
+    assert get_msg_2["entry"][0]["content"]["message"] == "new message to bulletin 2"
+
+    get_all_msg = bulletin_client_1.get_all_messages()
+    assert len(get_all_msg["entry"]) == 2
+
+    bulletin_client_1.delete_message()
+
+    with pytest.raises(binding.HTTPError) as e:
+        bulletin_client_1.get_message()
+    assert str(e.value.status) == "404"
+
+    with pytest.raises(binding.HTTPError) as e:
+        bulletin_client_1.delete_message()
+    assert str(e.value.status) == "404"
+
+    get_all_msg = bulletin_client_1.get_all_messages()
+    assert len(get_all_msg["entry"]) == 1
+
+    bulletin_client_2.delete_message()
+
+    get_all_msg = bulletin_client_1.get_all_messages()
+    assert len(get_all_msg["entry"]) == 0

--- a/tests/integration/test_bulletin_rest_client.py
+++ b/tests/integration/test_bulletin_rest_client.py
@@ -43,11 +43,15 @@ def test_bulletin_rest_api():
     assert get_msg_1["entry"][0]["content"]["message"] == "new message to bulletin"
     assert get_msg_1["entry"][0]["content"]["severity"] == "warn"
 
-    bulletin_client_1.create_message("new message to bulletin", bulletin_client_1.LogLevel.INFO)
+    bulletin_client_1.create_message(
+        "new message to bulletin", bulletin_client_1.LogLevel.INFO
+    )
     get_msg_1 = bulletin_client_1.get_message()
     assert get_msg_1["entry"][0]["content"]["severity"] == "info"
 
-    bulletin_client_1.create_message("new message to bulletin", bulletin_client_1.LogLevel.ERROR)
+    bulletin_client_1.create_message(
+        "new message to bulletin", bulletin_client_1.LogLevel.ERROR
+    )
     get_msg_1 = bulletin_client_1.get_message()
     assert get_msg_1["entry"][0]["content"]["severity"] == "error"
 

--- a/tests/integration/test_bulletin_rest_client.py
+++ b/tests/integration/test_bulletin_rest_client.py
@@ -39,14 +39,13 @@ def test_create_message():
         bulletin_client.create_message(
             "new message to bulletin",
             capabilities=["apps_restore", "unknown_cap"],
-            roles=["admin"]
+            roles=["admin"],
         )
     assert str(e.value.status) == "400"
 
     with pytest.raises(binding.HTTPError) as e:
         bulletin_client.create_message(
-            "new message to bulletin",
-            roles=["unknown_role"]
+            "new message to bulletin", roles=["unknown_role"]
         )
     assert str(e.value.status) == "400"
 
@@ -59,7 +58,7 @@ def test_bulletin_rest_api():
     bulletin_client_1.create_message(
         "new message to bulletin",
         capabilities=["apps_restore", "delete_messages"],
-        roles=["admin"]
+        roles=["admin"],
     )
 
     get_msg_1 = bulletin_client_1.get_message()

--- a/tests/unit/test_bulletin_rest_client.py
+++ b/tests/unit/test_bulletin_rest_client.py
@@ -18,12 +18,7 @@ import pytest
 from solnlib.bulletin_rest_client import BulletinRestClient
 
 
-context = {
-    "owner": "nobody",
-    "scheme": "https",
-    "host": "localhost",
-    "port": 8089
-}
+context = {"owner": "nobody", "scheme": "https", "host": "localhost", "port": 8089}
 
 
 def test_create_message(monkeypatch):
@@ -36,32 +31,33 @@ def test_create_message(monkeypatch):
 
     def new_post(*args, **kwargs) -> str:
         return "ok"
+
     monkeypatch.setattr(bulletin_client._rest_client, "post", new_post)
 
     bulletin_client.create_message(
-            "new message to bulletin",
-            capabilities=["apps_restore", "delete_messages"],
-            roles=["admin"]
+        "new message to bulletin",
+        capabilities=["apps_restore", "delete_messages"],
+        roles=["admin"],
     )
 
-    with pytest.raises(ValueError, match='Severity must be one of'):
+    with pytest.raises(ValueError, match="Severity must be one of"):
         bulletin_client.create_message(
             "new message to bulletin",
             severity="debug",
             capabilities=["apps_restore", "delete_messages", 1],
-            roles=["admin"]
+            roles=["admin"],
         )
 
-    with pytest.raises(ValueError, match='Capabilities must be a list of strings.'):
+    with pytest.raises(ValueError, match="Capabilities must be a list of strings."):
         bulletin_client.create_message(
             "new message to bulletin",
             capabilities=["apps_restore", "delete_messages", 1],
-            roles=["admin"]
+            roles=["admin"],
         )
 
-    with pytest.raises(ValueError, match='Roles must be a list of strings.'):
+    with pytest.raises(ValueError, match="Roles must be a list of strings."):
         bulletin_client.create_message(
             "new message to bulletin",
             capabilities=["apps_restore", "delete_messages"],
-            roles=["admin", 1]
+            roles=["admin", 1],
         )

--- a/tests/unit/test_bulletin_rest_client.py
+++ b/tests/unit/test_bulletin_rest_client.py
@@ -1,0 +1,67 @@
+#
+# Copyright 2024 Splunk Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import pytest
+from solnlib.bulletin_rest_client import BulletinRestClient
+
+
+context = {
+    "owner": "nobody",
+    "scheme": "https",
+    "host": "localhost",
+    "port": 8089
+}
+
+
+def test_create_message(monkeypatch):
+    session_key = "123"
+    bulletin_client = BulletinRestClient(
+        "msg_name_1",
+        session_key,
+        **context,
+    )
+
+    def new_post(*args, **kwargs) -> str:
+        return "ok"
+    monkeypatch.setattr(bulletin_client._rest_client, "post", new_post)
+
+    bulletin_client.create_message(
+            "new message to bulletin",
+            capabilities=["apps_restore", "delete_messages"],
+            roles=["admin"]
+    )
+
+    with pytest.raises(ValueError, match='Severity must be one of'):
+        bulletin_client.create_message(
+            "new message to bulletin",
+            severity="debug",
+            capabilities=["apps_restore", "delete_messages", 1],
+            roles=["admin"]
+        )
+
+    with pytest.raises(ValueError, match='Capabilities must be a list of strings.'):
+        bulletin_client.create_message(
+            "new message to bulletin",
+            capabilities=["apps_restore", "delete_messages", 1],
+            roles=["admin"]
+        )
+
+    with pytest.raises(ValueError, match='Roles must be a list of strings.'):
+        bulletin_client.create_message(
+            "new message to bulletin",
+            capabilities=["apps_restore", "delete_messages"],
+            roles=["admin", 1]
+        )

--- a/tests/unit/test_bulletin_rest_client.py
+++ b/tests/unit/test_bulletin_rest_client.py
@@ -26,6 +26,7 @@ def test_create_message(monkeypatch):
     bulletin_client = BulletinRestClient(
         "msg_name_1",
         session_key,
+        "_",
         **context,
     )
 


### PR DESCRIPTION
**Issue number:[ADDON-70528](https://splunk.atlassian.net/browse/ADDON-70528)**

## Summary

Create REST client to manage bulletin messages in splunk.

### Changes

* add bulletin_rest_client module with basic methods: CREATE, GET, GET ALL, DELETE 

### User experience

The user can better manage events in add-on by creating specific messages in the Splunk bulletin. Every message has 3 severity levels: info, warn, error. The user can also delete or read those messages at code lvl with the use of REST client. 

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [x] Changes are documented
* [x] PR title follows [conventional commit semantics](https://www.conventionalcommits.org/en/v1.0.0/)