### PR TITLE
fix: standalone HECEventwriter

### DIFF
--- a/solnlib/modular_input/event_writer.py
+++ b/solnlib/modular_input/event_writer.py
@@ -229,12 +229,11 @@ class HECEventWriter(EventWriter):
         else:
             self.logger = logging
 
-        if not all([scheme, host, port]):
-            scheme, host, port = get_splunkd_access_info()
-
         if hec_uri and hec_token:
             scheme, host, hec_port = utils.extract_http_scheme_host_port(hec_uri)
         else:
+            if not all([scheme, host, port]):
+                scheme, host, port = get_splunkd_access_info()
             hec_port, hec_token = self._get_hec_config(
                 hec_input_name, session_key, scheme, host, port, **context
             )


### PR DESCRIPTION
When create_from_token() is invoked, it triggers the HECEventWriter constructor with scheme, host, and port set to None. This leads to a get_splunkd_access_info() call, which throws an exception if the HEC URI doesn’t reference the local machine. As this call is unnecessary in such cases, its invocation has been relocated within the if-statement