### PR TITLE
feat: add log_level attribute

### DIFF
--- a/solnlib/log.py
+++ b/solnlib/log.py
@@ -79,7 +79,7 @@ class Logs(metaclass=Singleton):
     _default_directory = None
     _default_namespace = None
     _default_log_format = (
-        "%(asctime)s %(levelname)s pid=%(process)d tid=%(threadName)s "
+        "%(asctime)s log_level=%(levelname)s pid=%(process)d tid=%(threadName)s "
         "file=%(filename)s:%(funcName)s:%(lineno)d | %(message)s"
     )
     _default_log_level = logging.INFO


### PR DESCRIPTION
This PR adds a new event field to logs (log_level).

Example log before this change:

```
2024-07-15 10:01:22,969 ERROR pid=49789 tid=MainThread file=helper_one.py:stream_events:19 | Test log
```

Example log after this change:

```
2024-07-15 10:01:22,969 log_level=ERROR pid=49789 tid=MainThread file=helper_one.py:stream_events:19 | Test log
```