### PR TITLE
fix: add support of custom source in license usage

### DIFF
--- a/solnlib/log.py
+++ b/solnlib/log.py
@@ -285,6 +285,7 @@ def events_ingested(
     index: str,
     account: str = None,
     host: str = None,
+    license_usage_source: str = None,
 ):
     """Specific function to log the basic information of events ingested for
     the monitoring dashboard.
@@ -296,6 +297,7 @@ def events_ingested(
         sourcetype: Source type used to write event.
         n_events: Number of ingested events.
         index: Index used to write event.
+        license_usage_source: source used to match data with license_usage.log.
         account: Account used to write event. (optional)
         host: Host used to write event. (optional)
     """
@@ -310,7 +312,7 @@ def events_ingested(
 
     result = {
         "action": "events_ingested",
-        "modular_input_name": modular_input_name,
+        "modular_input_name": license_usage_source if license_usage_source else modular_input_name,
         "sourcetype_ingested": sourcetype,
         "n_events": n_events,
         "event_input": input_name,

--- a/solnlib/log.py
+++ b/solnlib/log.py
@@ -312,7 +312,9 @@ def events_ingested(
 
     result = {
         "action": "events_ingested",
-        "modular_input_name": license_usage_source if license_usage_source else modular_input_name,
+        "modular_input_name": license_usage_source
+        if license_usage_source
+        else modular_input_name,
         "sourcetype_ingested": sourcetype,
         "n_events": n_events,
         "event_input": input_name,

--- a/tests/integration/test_bulletin_rest_client.py
+++ b/tests/integration/test_bulletin_rest_client.py
@@ -58,7 +58,7 @@ def test_bulletin_rest_api():
 
     bulletin_client_1.create_message(
         "new message to bulletin",
-        capabilities=["apps_restore", "delete_messages"],
+        capabilities=["apps_restore", "edit_roles"],
         roles=["admin"],
     )
 

--- a/tests/integration/test_bulletin_rest_client.py
+++ b/tests/integration/test_bulletin_rest_client.py
@@ -115,7 +115,7 @@ def _clear_bulletin():
     session_key = context.get_session_key()
     bulletin_client = _build_bulletin_manager("", session_key)
 
-    msg_to_del = [el['name'] for el in bulletin_client.get_all_messages()['entry']]
+    msg_to_del = [el["name"] for el in bulletin_client.get_all_messages()["entry"]]
     for msg in msg_to_del:
         endpoint = f"{bulletin_client.MESSAGES_ENDPOINT}/{msg}"
         bulletin_client._rest_client.delete(endpoint)

--- a/tests/integration/test_bulletin_rest_client.py
+++ b/tests/integration/test_bulletin_rest_client.py
@@ -56,6 +56,9 @@ def test_bulletin_rest_api():
     bulletin_client_1 = _build_bulletin_manager("msg_name_1", session_key)
     bulletin_client_2 = _build_bulletin_manager("msg_name_2", session_key)
 
+    # clear bulletin before tests
+    _clear_bulletin()
+
     bulletin_client_1.create_message(
         "new message to bulletin",
         capabilities=["apps_restore", "edit_roles"],
@@ -106,3 +109,13 @@ def test_bulletin_rest_api():
 
     get_all_msg = bulletin_client_1.get_all_messages()
     assert len(get_all_msg["entry"]) == 0
+
+
+def _clear_bulletin():
+    session_key = context.get_session_key()
+    bulletin_client = _build_bulletin_manager("", session_key)
+
+    msg_to_del = [el['name'] for el in bulletin_client.get_all_messages()['entry']]
+    for msg in msg_to_del:
+        endpoint = f"{bulletin_client.MESSAGES_ENDPOINT}/{msg}"
+        bulletin_client._rest_client.delete(endpoint)

--- a/tests/unit/test_log.py
+++ b/tests/unit/test_log.py
@@ -243,6 +243,38 @@ def test_events_ingested_invalid_input():
     assert exp_msg == str(excinfo.value)
 
 
+def test_events_ingested_custom_license_usage():
+    with mock.patch("logging.Logger") as mock_logger:
+        log.events_ingested(
+            mock_logger, "input_type://input_name", "sourcetype", 5, "default",
+            license_usage_source="custom:license:source"
+        )
+
+        mock_logger.log.assert_called_once_with(
+            logging.INFO,
+            "action=events_ingested modular_input_name=custom:license:source sourcetype_ingested=sourcetype "
+            "n_events=5 event_input=input_name event_index=default",
+        )
+
+    with mock.patch("logging.Logger") as mock_logger:
+        log.events_ingested(
+            mock_logger,
+            "demo://modular_input_name",
+            "sourcetype",
+            5,
+            "default",
+            host="abcd",
+            account="test_acc",
+            license_usage_source="custom:license:source:123"
+        )
+
+        mock_logger.log.assert_called_once_with(
+            logging.INFO,
+            "action=events_ingested modular_input_name=custom:license:source:123 sourcetype_ingested=sourcetype n_"
+            "events=5 event_input=modular_input_name event_index=default event_account=test_acc event_host=abcd",
+        )
+
+
 def test_log_exceptions_full_msg():
     start_msg = "some msg before exception"
     with mock.patch("logging.Logger") as mock_logger:
@@ -318,13 +350,13 @@ def test_log_format(monkeypatch, tmp_path):
     log_content = transform_log(log_file.read_text())
 
     assert (
-        log_content
-        == dedent(
-            """
-            2024-03-23 10:15:20,555 log_level=WARNING pid=1234 tid=MainThread file=test_file.py:test_func:123 | log 2
-            2024-03-23 10:15:20,555 log_level=ERROR pid=1234 tid=MainThread file=test_file.py:test_func:123 | log 3
-        """,
-        ).lstrip()
+            log_content
+            == dedent(
+        """
+        2024-03-23 10:15:20,555 log_level=WARNING pid=1234 tid=MainThread file=test_file.py:test_func:123 | log 2
+        2024-03-23 10:15:20,555 log_level=ERROR pid=1234 tid=MainThread file=test_file.py:test_func:123 | log 3
+    """,
+    ).lstrip()
     )
 
 

--- a/tests/unit/test_log.py
+++ b/tests/unit/test_log.py
@@ -246,8 +246,12 @@ def test_events_ingested_invalid_input():
 def test_events_ingested_custom_license_usage():
     with mock.patch("logging.Logger") as mock_logger:
         log.events_ingested(
-            mock_logger, "input_type://input_name", "sourcetype", 5, "default",
-            license_usage_source="custom:license:source"
+            mock_logger,
+            "input_type://input_name",
+            "sourcetype",
+            5,
+            "default",
+            license_usage_source="custom:license:source",
         )
 
         mock_logger.log.assert_called_once_with(
@@ -265,7 +269,7 @@ def test_events_ingested_custom_license_usage():
             "default",
             host="abcd",
             account="test_acc",
-            license_usage_source="custom:license:source:123"
+            license_usage_source="custom:license:source:123",
         )
 
         mock_logger.log.assert_called_once_with(
@@ -350,13 +354,13 @@ def test_log_format(monkeypatch, tmp_path):
     log_content = transform_log(log_file.read_text())
 
     assert (
-            log_content
-            == dedent(
-        """
+        log_content
+        == dedent(
+            """
         2024-03-23 10:15:20,555 log_level=WARNING pid=1234 tid=MainThread file=test_file.py:test_func:123 | log 2
         2024-03-23 10:15:20,555 log_level=ERROR pid=1234 tid=MainThread file=test_file.py:test_func:123 | log 3
     """,
-    ).lstrip()
+        ).lstrip()
     )
 
 


### PR DESCRIPTION
**Issue number: [ADDON-72793](https://splunk.atlassian.net/browse/ADDON-72793)**

## Summary

Added support for custom source in license usage

### Changes
function `events_ingested` has new optional parameter `license_usage_source`. If provided this value will be save as `modular_input_name`.

## Checklist

* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [x] Changes are documented
* [x] PR title follows [conventional commit semantics](https://www.conventionalcommits.org/en/v1.0.0/)