### PR TITLE
fix splunk config parsing issue in Python 3.13

### DIFF
--- a/solnlib/splunkenv.py
+++ b/solnlib/splunkenv.py
@@ -309,7 +309,7 @@ def get_conf_stanzas(conf_name: str) -> dict:
 
     parser = ConfigParser(**{"strict": False})
     parser.optionxform = str
-    parser.readfp(StringIO(out))
+    parser.read_file(StringIO(out))
 
     out = {}
     for section in parser.sections():


### PR DESCRIPTION
fixed AttributeError: 'ConfigParser' object has no attribute 'readfp'. Did you mean: 'read'?