### PR TITLE
ci: fix ubuntu version to 22.04

### DIFF
--- a/.github/workflows/build-test-release.yml
+++ b/.github/workflows/build-test-release.yml
@@ -50,12 +50,12 @@ jobs:
       - uses: apache/skywalking-eyes@v0.6.0
 
   pre-commit:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
-          python-version: "3.12"
+          python-version: "3.7"
       - uses: pre-commit/action@v3.0.1
 
   semgrep:

--- a/.github/workflows/build-test-release.yml
+++ b/.github/workflows/build-test-release.yml
@@ -50,12 +50,12 @@ jobs:
       - uses: apache/skywalking-eyes@v0.6.0
 
   pre-commit:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
-          python-version: "3.7"
+          python-version: "3.12"
       - uses: pre-commit/action@v3.0.1
 
   semgrep:

--- a/.github/workflows/build-test-release.yml
+++ b/.github/workflows/build-test-release.yml
@@ -50,7 +50,7 @@ jobs:
       - uses: apache/skywalking-eyes@v0.6.0
 
   pre-commit:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
@@ -66,7 +66,7 @@ jobs:
 
   run-unit-tests:
     name: test-unit ${{ matrix.python-version }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     continue-on-error: true
     strategy:
       matrix:
@@ -87,7 +87,7 @@ jobs:
           poetry run pytest tests/unit
 
   test-splunk:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     continue-on-error: true
     needs:
       - meta
@@ -143,7 +143,7 @@ jobs:
       - semgrep
       - run-unit-tests
       - test-splunk
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -13,7 +13,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
-          python-version: 3.7
+          python-version: 3.12
       - run: curl -sSL https://install.python-poetry.org | python3 - --version 1.5.1
       - run: |
           poetry install

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,11 +9,11 @@ repos:
     hooks:
     -   id: black
 -   repo: https://github.com/myint/docformatter
-    rev: v1.5.0
+    rev: v1.7.5
     hooks:
       - id: docformatter
         args: [--in-place]
 -   repo: https://github.com/PyCQA/flake8
-    rev: 5.0.4
+    rev: 7.1.1
     hooks:
     -   id: flake8

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,11 +9,11 @@ repos:
     hooks:
     -   id: black
 -   repo: https://github.com/myint/docformatter
-    rev: v1.7.5
+    rev: v1.5.0
     hooks:
       - id: docformatter
         args: [--in-place]
 -   repo: https://github.com/PyCQA/flake8
-    rev: 7.1.1
+    rev: 5.0.4
     hooks:
     -   id: flake8


### PR DESCRIPTION
This PR sets ubuntu version to 22.04 for scripts run with python 3.7.
Reference: [ADDON-75861](https://splunk.atlassian.net/browse/ADDON-75861)

Python version for pre-commit can not be updated to latest version due to open issue with the docformatter hook.
Reference: https://github.com/PyCQA/docformatter/issues/289, https://github.com/PyCQA/docformatter/issues/293