### PR TITLE
chore(pyproject): explicitly specify supported Python versions

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -991,5 +991,5 @@ testing = ["big-O", "flake8 (<5)", "jaraco.functools", "jaraco.itertools", "more
 
 [metadata]
 lock-version = "2.0"
-python-versions = "^3.7"
-content-hash = "cc7429f4b20b51e8c6148a9ba7a851d7f823bccf0a2e1aae58b761e159d4021b"
+python-versions = ">=3.7,<3.14"
+content-hash = "355e3165623b332a6856b7959863e7dbf61f9f22fc0b880aede1d84cc3c53dba"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,9 +21,25 @@ description = "The Splunk Software Development Kit for Splunk Solutions"
 authors = ["Splunk <addonfactory@splunk.com>"]
 license = "Apache-2.0"
 repository = "https://github.com/splunk/addonfactory-solutions-library-python"
+keywords = ["splunk", "ucc"]
+classifiers = [
+    "Programming Language :: Python",
+    "Development Status :: 5 - Production/Stable",
+    "Intended Audience :: Developers",
+    "Topic :: Software Development :: Libraries :: Python Modules",
+    "Topic :: Software Development :: Code Generators",
+    "License :: OSI Approved :: Apache Software License",
+    "Programming Language :: Python :: 3.7",
+    "Programming Language :: Python :: 3.8",
+    "Programming Language :: Python :: 3.9",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+]
 
 [tool.poetry.dependencies]
-python = "^3.7"
+python = ">=3.7,<3.14"
 requests = "^2.31.0"
 urllib3 = "<2"
 sortedcontainers = ">=2"


### PR DESCRIPTION
Similar to https://github.com/splunk/addonfactory-ucc-generator/pull/1452.

So we could properly see the classifiers on PyPI (see screenshot below).

<img width="339" alt="image" src="https://github.com/user-attachments/assets/e51fd0f3-9056-4a19-a53e-77cf381a8402">
