### PR TITLE
BREAKING CHANGE: removed requests from solnlib's dependencies

### DIFF
--- a/docs/release_6_0_0.md
+++ b/docs/release_6_0_0.md
@@ -1,10 +1,16 @@
 # Removed requests and urllib3 from solnlib
-
 The `requests` and `urllib3` libraries has been removed from solnlib, so solnlib now depends on the `requests` and `urllib3` libraries from the running environment.
 By default, Splunk delivers the above libraries and their version depends on the Splunk version. More information [here](https://docs.splunk.com/Documentation/Splunk/9.2.3/ReleaseNotes/Credits).
 
 **IMPORTANT**: `urllib3` is available in Splunk `v8.1.0` and later
 
 Please note that if `requests` or `urllib3` are installed in `<Add-on>/lib` e.g. as a dependency of another library, that version will be taken first.
-If `requests` or `urllib3` is missing in the add-on's `lib` directory, the version provided by Splunk will be used. In case the Splunk `requests` or `urllib3` version is not sufficient for you,
+If `requests` or `urllib3` is missing in the add-on's `lib` directory, the version provided by Splunk will be used.
+
+## Custom Version of requests and urllib3
+In case the Splunk's `requests` or `urllib3` version is not sufficient for you, 
 you can deliver version you need by simply adding it to the `requirements.txt` or `pyproject.toml` file in your add-on.
+
+## Use solnlib outside the Splunk
+**Solnlib** no longer provides `requests` and `urllib3` so if you want to use **solnlib** outside the Splunk, please note that you will need to
+provide these libraries yourself in the environment where **solnlib** is used.

--- a/docs/release_6_0_0.md
+++ b/docs/release_6_0_0.md
@@ -1,0 +1,8 @@
+# Removed requests from solnlib
+
+The `requests` library has been removed from solnlib, so solnlib now depends on the `requests` library from the running environment.
+By default, splunk delivers `requests` whose version depends on the splunk version. More information [here](https://docs.splunk.com/Documentation/Splunk/9.2.3/ReleaseNotes/Credits).
+
+Please note that if `requests` are installed in `<Add-on>/lib` e.g. as a dependency of another library, that version will be taken first. 
+If `requests` are missing from the add-on's `lib` directory, then `requests` provided from splunk will be used. In case the splunk `requests` version is not sufficient for you,
+you can deliver version you need by simply adding it to the `requirements.txt` or `pyproject.toml` file in your add-on.

--- a/docs/release_6_0_0.md
+++ b/docs/release_6_0_0.md
@@ -1,8 +1,10 @@
-# Removed requests from solnlib
+# Removed requests and urllib3 from solnlib
 
-The `requests` library has been removed from solnlib, so solnlib now depends on the `requests` library from the running environment.
-By default, splunk delivers `requests` whose version depends on the splunk version. More information [here](https://docs.splunk.com/Documentation/Splunk/9.2.3/ReleaseNotes/Credits).
+The `requests` and `urllib3` libraries has been removed from solnlib, so solnlib now depends on the `requests` and `urllib3` libraries from the running environment.
+By default, Splunk delivers the above libraries and their version depends on the Splunk version. More information [here](https://docs.splunk.com/Documentation/Splunk/9.2.3/ReleaseNotes/Credits).
 
-Please note that if `requests` are installed in `<Add-on>/lib` e.g. as a dependency of another library, that version will be taken first. 
-If `requests` are missing from the add-on's `lib` directory, then `requests` provided from splunk will be used. In case the splunk `requests` version is not sufficient for you,
+**IMPORTANT**: `urllib3` is available in Splunk `v8.1.0` and later
+
+Please note that if `requests` or `urllib3` are installed in `<Add-on>/lib` e.g. as a dependency of another library, that version will be taken first.
+If `requests` or `urllib3` is missing in the add-on's `lib` directory, the version provided by Splunk will be used. In case the Splunk `requests` or `urllib3` version is not sufficient for you,
 you can deliver version you need by simply adding it to the `requirements.txt` or `pyproject.toml` file in your add-on.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -30,6 +30,7 @@ plugins:
 
 nav:
   - Home: index.md
+  - Release 6.0.0: release_6_0_0.md
   - References:
       - modular_input:
           - "checkpointer.py": modular_input/checkpointer.md

--- a/poetry.lock
+++ b/poetry.lock
@@ -727,7 +727,6 @@ files = [
     {file = "PyYAML-6.0.1-cp311-cp311-win_amd64.whl", hash = "sha256:bf07ee2fef7014951eeb99f56f39c9bb4af143d8aa3c21b1677805985307da34"},
     {file = "PyYAML-6.0.1-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:855fb52b0dc35af121542a76b9a84f8d1cd886ea97c84703eaa6d88e37a2ad28"},
     {file = "PyYAML-6.0.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:40df9b996c2b73138957fe23a16a4f0ba614f4c0efce1e9406a184b6d07fa3a9"},
-    {file = "PyYAML-6.0.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a08c6f0fe150303c1c6b71ebcd7213c2858041a7e01975da3a99aed1e7a378ef"},
     {file = "PyYAML-6.0.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6c22bec3fbe2524cde73d7ada88f6566758a8f7227bfbf93a408a9d86bcc12a0"},
     {file = "PyYAML-6.0.1-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:8d4e9c88387b0f5c7d5f281e55304de64cf7f9c0021a3525bd3b1c542da3b0e4"},
     {file = "PyYAML-6.0.1-cp312-cp312-win32.whl", hash = "sha256:d483d2cdf104e7c9fa60c544d92981f12ad66a457afae824d146093b8c294c54"},
@@ -1024,4 +1023,4 @@ testing = ["big-O", "flake8 (<5)", "jaraco.functools", "jaraco.itertools", "more
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.7,<3.14"
-content-hash = "355e3165623b332a6856b7959863e7dbf61f9f22fc0b880aede1d84cc3c53dba"
+content-hash = "e24950c3694801361bf9956c190d77a0c5f2fdb82786f4a101ab50de34932920"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,6 @@ classifiers = [
 
 [tool.poetry.dependencies]
 python = ">=3.7,<3.14"
-urllib3 = "<2"
 sortedcontainers = ">=2"
 defusedxml = ">=0.7"
 splunk-sdk = ">=1.6"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,6 @@ classifiers = [
 
 [tool.poetry.dependencies]
 python = ">=3.7,<3.14"
-requests = "^2.31.0"
 urllib3 = "<2"
 sortedcontainers = ">=2"
 defusedxml = ">=0.7"


### PR DESCRIPTION
**Issue number:[ADDON-73536](https://splunk.atlassian.net/browse/ADDON-73536)**

### PR Type

**What kind of change does this PR introduce?**
* [x] Breaking change
* [ ] Feature
* [ ] Bug Fix
* [ ] Refactoring (no functional or API changes)
* [ ] Documentation Update
* [ ] Maintenance (dependency updates, CI, etc.)

## Summary

The requests library has been removed from solnlib, so solnlib now depends on the requests library from the running environment.

### Changes

removed requests from pyproject.toml

### User experience

Solnlib will no longer install requests library. if requests are installed in `<Add-on>/lib` e.g. as a dependency of another library, that version will be taken first. If requests is missing from the add-on’s lib directory, then requests provided from splunk will be used. In case the splunk requests version is not sufficient for the user, user can deliver version he needs by simply adding it to the requirements.txt or pyproject.toml file in the add-on.

## Checklist

If an item doesn't apply to your changes, leave it unchecked.

* [x] I have performed a self-review of this change according to the [development guidelines](https://splunk.github.io/addonfactory-ucc-generator/contributing/#development-guidelines)
* [x] Tests have been added/modified to cover the changes [(testing doc)](https://splunk.github.io/addonfactory-ucc-generator/contributing/#build-and-test)
* [x] Changes are documented
* [x] PR title and description follows the [contributing principles](https://splunk.github.io/addonfactory-ucc-generator/contributing/#pull-requests)
