### PR TITLE
fix: require splunk-sdk at least 2.0.2

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -727,6 +727,7 @@ files = [
     {file = "PyYAML-6.0.1-cp311-cp311-win_amd64.whl", hash = "sha256:bf07ee2fef7014951eeb99f56f39c9bb4af143d8aa3c21b1677805985307da34"},
     {file = "PyYAML-6.0.1-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:855fb52b0dc35af121542a76b9a84f8d1cd886ea97c84703eaa6d88e37a2ad28"},
     {file = "PyYAML-6.0.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:40df9b996c2b73138957fe23a16a4f0ba614f4c0efce1e9406a184b6d07fa3a9"},
+    {file = "PyYAML-6.0.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a08c6f0fe150303c1c6b71ebcd7213c2858041a7e01975da3a99aed1e7a378ef"},
     {file = "PyYAML-6.0.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6c22bec3fbe2524cde73d7ada88f6566758a8f7227bfbf93a408a9d86bcc12a0"},
     {file = "PyYAML-6.0.1-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:8d4e9c88387b0f5c7d5f281e55304de64cf7f9c0021a3525bd3b1c542da3b0e4"},
     {file = "PyYAML-6.0.1-cp312-cp312-win32.whl", hash = "sha256:d483d2cdf104e7c9fa60c544d92981f12ad66a457afae824d146093b8c294c54"},
@@ -1023,4 +1024,4 @@ testing = ["big-O", "flake8 (<5)", "jaraco.functools", "jaraco.itertools", "more
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.7,<3.14"
-content-hash = "e24950c3694801361bf9956c190d77a0c5f2fdb82786f4a101ab50de34932920"
+content-hash = "7296af4efc8a409147dfcfc840895f32432578649836d5906506225d3be8e58a"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,7 +42,7 @@ classifiers = [
 python = ">=3.7,<3.14"
 sortedcontainers = ">=2"
 defusedxml = ">=0.7"
-splunk-sdk = ">=1.6"
+splunk-sdk = ">=2.0.2"
 
 [tool.poetry.group.dev.dependencies]
 pytest = ">=7"


### PR DESCRIPTION
Jira: https://splunk.atlassian.net/browse/ADDON-77054

This PR makes sure that `solnlib` will require at least `2.0.2` version of `splunk-sdk`.