### PR TITLE
Fix config stanza reading login in the splunkenv.py

### DIFF
--- a/solnlib/splunkenv.py
+++ b/solnlib/splunkenv.py
@@ -298,6 +298,7 @@ def get_conf_stanzas(conf_name: str) -> dict:
         "btool",
         conf_name,
         "list",
+        "--app=system",
     ]
     p = subprocess.Popen(  # nosemgrep: python.lang.security.audit.dangerous-subprocess-use.dangerous-subprocess-use
         btool_cli, stdout=subprocess.PIPE, stderr=subprocess.PIPE


### PR DESCRIPTION
Method get_conf_stanzas internally calls 
`$SPLUNK_HOME/bin/splunk cmd btool server list`
This command leads to **accumulated** output. It reads `server.conf` files from all apps.
Such behaviour may lead to invalid results, if an app has different (not supported) format in the conf file.

I suggest to change login and read configs only from the `system` app:
`$SPLUNK_HOME/bin/splunk cmd btool server list --app=system`