### PR TITLE
fix: change log_exception format

### DIFF
--- a/solnlib/log.py
+++ b/solnlib/log.py
@@ -352,7 +352,7 @@ def log_exception(
     """
 
     msg = _get_exception_message(e, full_msg, msg_before, msg_after)
-    logger.log(log_level, f'exc_l="{exc_label}" {msg}')
+    logger.log(log_level, f'exc_l="{exc_label}" | {msg}')
 
 
 def _get_exception_message(
@@ -367,7 +367,7 @@ def _get_exception_message(
     else:
         error = traceback.format_exception_only(exc_type, exc_value)
 
-    msg_start = msg_before if msg_before is not None else ""
-    msg_mid = "".join(error)
-    msg_end = msg_after if msg_after is not None else ""
-    return f"{msg_start}\n{msg_mid}\n{msg_end}"
+    msg_start = msg_before + " | " if msg_before is not None else ""
+    msg_mid = "".join(error).replace("\n", " ").rstrip()
+    msg_end = " | " + msg_after if msg_after is not None else ""
+    return f"{msg_start}{msg_mid}{msg_end}"

--- a/tests/unit/test_log.py
+++ b/tests/unit/test_log.py
@@ -288,9 +288,10 @@ def test_log_exceptions_full_msg():
             json.loads(test_jsons)
         except Exception as e:
             log.log_exception(mock_logger, e, "test type1", msg_before=start_msg)
+            err_msg = traceback.format_exc().replace("\n", " ").rstrip()
             mock_logger.log.assert_called_with(
                 logging.ERROR,
-                f'exc_l="test type1" {start_msg}\n{traceback.format_exc()}\n',
+                f'exc_l="test type1" | {start_msg} | {err_msg}',
             )
 
 
@@ -312,8 +313,8 @@ def test_log_exceptions_partial_msg():
             )
             mock_logger.log.assert_called_with(
                 logging.ERROR,
-                'exc_l="test type" some msg before exception\njson.decoder.JSONDecodeError: Expecting property '
-                "name enclosed in double quotes: line 1 column 2 (char 1)\n\nsome msg after exception",
+                'exc_l="test type" | some msg before exception | json.decoder.JSONDecodeError: Expecting property '
+                "name enclosed in double quotes: line 1 column 2 (char 1) | some msg after exception",
             )
 
 
@@ -337,8 +338,9 @@ def test_log_basic_error(func, result):
         except AddonComplexError as e:
             fun = getattr(log, func)
             fun(mock_logger, e)
+            err_msg = traceback.format_exc().replace("\n", " ").rstrip()
             mock_logger.log.assert_called_with(
-                logging.ERROR, f"exc_l={result} \n{traceback.format_exc()}\n"
+                logging.ERROR, f"exc_l={result} | {err_msg}"
             )
 
 


### PR DESCRIPTION
**Issue number:** 

### PR Type

**What kind of change does this PR introduce?**
* [ ] Feature
* [x] Bug Fix
* [ ] Refactoring (no functional or API changes)
* [ ] Documentation Update
* [ ] Maintenance (dependency updates, CI, etc.)

## Summary

### Changes

Currently `splunk search` displays error logs from `log_exception` method as a separate events as they are using lots of newlines chars. Idea was to reformat those logs to have everything in one event.


## Checklist

If an item doesn't apply to your changes, leave it unchecked.

### Review

* [x] self-review - I have performed a self-review of this change according to the [development guidelines](https://splunk.github.io/addonfactory-ucc-generator/contributing/#development-guidelines)
* [ ] Changes are documented. The documentation is understandable, examples work [(more info)](https://splunk.github.io/addonfactory-ucc-generator/contributing/#documentation-guidelines)
* [x] PR title and description follows the [contributing principles](https://splunk.github.io/addonfactory-ucc-generator/contributing/#pull-requests)
* [ ] meeting - I have scheduled a meeting or recorded a demo to explain these changes (if there is a video, put a link below and in the ticket)

### Tests

See [the testing doc](https://splunk.github.io/addonfactory-ucc-generator/contributing/#build-and-test).

* [x] Unit - tests have been added/modified to cover the changes
* [ ] Smoke - tests have been added/modified to cover the changes
* [ ] UI - tests have been added/modified to cover the changes
